### PR TITLE
Add firefox compatibility

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -28,5 +28,12 @@
   "web_accessible_resources": [
     "js/csrf-setter.js"
   ],
-  "manifest_version": 2
+  "manifest_version": 2,
+  "applications": {
+    "gecko": {
+      "id": "aws-extend-switch-roles@tilfin.github.com",
+      "strict_min_version": "54.0.1",
+      "strict_max_version": "*"
+    }
+  }
 }

--- a/popup.html
+++ b/popup.html
@@ -25,7 +25,7 @@ a { text-decoration: none }
 #awsConfigTextArea {
   padding: 0.5ex;
   resize: none;
-  white-space: nowrap;
+  // white-space: nowrap;
   width:470px;
   height:400px;
 }


### PR DESCRIPTION
For firefox, an ID must be defined so that the webextension can use
the local storage. I defined a random one based on the project
name and author.
Also I defined a min version corresponding to the tests I was able
to do - it may be compatible to previous versions (tests needed).
Finally, it seems a CSS property causes issue with the textarea,
so I removed it. It seems to have no impact in Chrome ?

Now it is possible to (locally) load the extension in FF, however
only in local testing mode (it only lasts until FF restart).
To allow this extension to be used on Firefox for everybody in a
definitive way, there is a submission process so that this
extension is validated and signed by mozilla, and published
in https://addons.mozilla.org/fr/firefox/ :
* https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Publishing_your_WebExtension