### PR TITLE
Add images to each profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The simplest configuration is for multiple **target roles** when you always inte
 
 * A 'color' parameter can be used to specify an RGB hex value without prefix '#'.
 * A 'region' parameter can be used to change the region whenever switching the role.
+* An 'image' parameter can be used to specify the uri of an image to use on top of any color attribute supplied. The color and image are not mutually exclusive.
 
 ```
 [profile marketingadmin]
@@ -42,6 +43,11 @@ color = ffaaee
 aws_account_id = 987654321987
 role_name = anotherrole
 region=ap-northeast-1
+
+[athirdaccount]
+aws_account_id = 987654321988
+role_name = athirdrole
+image = "https://via.placeholder.com/150"
 ```
 
 ### Complex Configuration

--- a/src/lib/content.js
+++ b/src/lib/content.js
@@ -219,7 +219,7 @@ function attachColorLine(profiles) {
     const color = found && found.color || null;
 
     var label = usernameMenu.querySelector('.nav-elt-label');
-    if (found.image) {
+    if (found && found.image) {
         label.insertAdjacentHTML('beforebegin', Sanitizer.escapeHTML(`<img src=${found.image.replace(/"/g, '')} width="17em" height="17em" style="float: left; padding-right: 1em">`));
     }
 

--- a/src/lib/content.js
+++ b/src/lib/content.js
@@ -220,7 +220,7 @@ function attachColorLine(profiles) {
 
     var label = usernameMenu.querySelector('.nav-elt-label');
     if (found && found.image) {
-        label.insertAdjacentHTML('beforebegin', Sanitizer.escapeHTML(`<img src=${found.image.replace(/"/g, '')} width="17em" height="17em" style="float: left; padding-right: 1em">`));
+        label.insertAdjacentHTML('beforebegin', Sanitizer.escapeHTML(`<img id="AESW_Image" src=${found.image.replace(/"/g, '')} width="17em" height="17em" style="float: left; padding-right: 1em">`));
     }
 
     if (color) {

--- a/src/lib/content.js
+++ b/src/lib/content.js
@@ -122,20 +122,38 @@ function loadProfiles(profile, list, csrf, hidesHistory, hidesAccountId) {
     if (recentNames.indexOf(name) !== -1) return true;
 
     var color = item.color || 'aaaaaa';
-    list.insertAdjacentHTML('beforeend', Sanitizer.escapeHTML`<li>
-     <form action="https://signin.aws.amazon.com/switchrole" method="POST" target="_top" data-aesr-profile="${item.profile}">
-      <input type="hidden" name="action" value="switchFromBasis">
-      <input type="hidden" name="src" value="nav">
-      <input type="hidden" name="roleName" value="${item.role_name}">
-      <input type="hidden" name="account" value="${item.aws_account_id}">
-      <input type="hidden" name="mfaNeeded" value="0">
-      <input type="hidden" name="color" value="${color}">
-      <input type="hidden" name="csrf" value="${csrf}">
-      <input type="hidden" name="redirect_uri" value="${redirectUri}">
-      <label for="awsc-recent-role-switch-0" class="awsc-role-color" style="background-color: #${color};">&nbsp;</label>
-      <input type="submit" class="awsc-role-submit awsc-role-display-name" name="displayName" value="${name}"
-            title="${item.role_name}@${item.aws_account_id}" style="white-space:pre"></form>
-    </li>`);
+    if (!item.image) {
+        list.insertAdjacentHTML('beforeend', Sanitizer.escapeHTML`<li>
+         <form action="https://signin.aws.amazon.com/switchrole" method="POST" target="_top" data-aesr-profile="${item.profile}">
+          <input type="hidden" name="action" value="switchFromBasis">
+          <input type="hidden" name="src" value="nav">
+          <input type="hidden" name="roleName" value="${item.role_name}">
+          <input type="hidden" name="account" value="${item.aws_account_id}">
+          <input type="hidden" name="mfaNeeded" value="0">
+          <input type="hidden" name="color" value="${color}">
+          <input type="hidden" name="csrf" value="${csrf}">
+          <input type="hidden" name="redirect_uri" value="${redirectUri}">
+          <label for="awsc-recent-role-switch-0" class="awsc-role-color" style="background-color: #${color};">&nbsp;</label>
+          <input type="submit" class="awsc-role-submit awsc-role-display-name" name="displayName" value="${name}"
+                title="${item.role_name}@${item.aws_account_id}" style="white-space:pre"></form>
+        </li>`);
+    } else {
+        list.insertAdjacentHTML('beforeend', Sanitizer.escapeHTML`<li>
+         <form action="https://signin.aws.amazon.com/switchrole" method="POST" target="_top" data-aesr-profile="${item.profile}">
+          <input type="hidden" name="action" value="switchFromBasis">
+          <input type="hidden" name="src" value="nav">
+          <input type="hidden" name="roleName" value="${item.role_name}">
+          <input type="hidden" name="account" value="${item.aws_account_id}">
+          <input type="hidden" name="mfaNeeded" value="0">
+          <input type="hidden" name="color" value="${color}">
+          <input type="hidden" name="csrf" value="${csrf}">
+          <input type="hidden" name="redirect_uri" value="${redirectUri}">
+          <label for="awsc-recent-role-switch-0" class="awsc-role-color"><img src=${item.image.replace(/"/g, '')} width="100%" height="100%"></label>
+          <input type="submit" class="awsc-role-submit awsc-role-display-name" name="displayName" value="${name}"
+                title="${item.role_name}@${item.aws_account_id}" style="white-space:pre"></form>
+        </li>`);
+
+    }
   });
 
   Array.from(list.querySelectorAll('form')).forEach(form => {
@@ -200,9 +218,13 @@ function attachColorLine(profiles) {
     const found = profiles.find(item => { return item.profile === profileName });
     const color = found && found.color || null;
 
+    var label = usernameMenu.querySelector('.nav-elt-label');
+    if (found.image) {
+        label.insertAdjacentHTML('beforebegin', Sanitizer.escapeHTML(`<img src=${found.image.replace(/"/g, '')} width="17em" height="17em" style="float: left; padding-right: 1em">`));
+    }
+
     if (color) {
       if (needsInvertForeColorByBack(color)) {
-        var label = usernameMenu.querySelector('.nav-elt-label');
         label.style = 'color: #eee';
       }
 

--- a/src/lib/content.js
+++ b/src/lib/content.js
@@ -148,7 +148,7 @@ function loadProfiles(profile, list, csrf, hidesHistory, hidesAccountId) {
           <input type="hidden" name="color" value="${color}">
           <input type="hidden" name="csrf" value="${csrf}">
           <input type="hidden" name="redirect_uri" value="${redirectUri}">
-          <label for="awsc-recent-role-switch-0" class="awsc-role-color"><img src=${item.image.replace(/"/g, '')} width="14em" height="14em"></label>
+          <label for="awsc-recent-role-switch-0" class="awsc-role-color"><img src=${item.image.replace(/"/g, '')} style="width: 1em; height: 1em"></label>
           <input type="submit" class="awsc-role-submit awsc-role-display-name" name="displayName" value="${name}"
                 title="${item.role_name}@${item.aws_account_id}" style="white-space:pre"></form>
         </li>`);
@@ -220,7 +220,7 @@ function attachColorLine(profiles) {
 
     var label = usernameMenu.querySelector('.nav-elt-label');
     if (found && found.image) {
-        label.insertAdjacentHTML('beforebegin', Sanitizer.escapeHTML(`<img id="AESW_Image" src=${found.image.replace(/"/g, '')} width="14em" height="14em" style="float: left; padding-right: 1em">`));
+        label.insertAdjacentHTML('beforebegin', Sanitizer.escapeHTML(`<img id="AESW_Image" src=${found.image.replace(/"/g, '')} style="float: left; padding-right: 1em; width: 1em; height: 1em">`));
     }
 
     if (color) {

--- a/src/lib/content.js
+++ b/src/lib/content.js
@@ -148,7 +148,7 @@ function loadProfiles(profile, list, csrf, hidesHistory, hidesAccountId) {
           <input type="hidden" name="color" value="${color}">
           <input type="hidden" name="csrf" value="${csrf}">
           <input type="hidden" name="redirect_uri" value="${redirectUri}">
-          <label for="awsc-recent-role-switch-0" class="awsc-role-color"><img src=${item.image.replace(/"/g, '')} width="100%" height="100%"></label>
+          <label for="awsc-recent-role-switch-0" class="awsc-role-color"><img src=${item.image.replace(/"/g, '')} width="14em" height="14em"></label>
           <input type="submit" class="awsc-role-submit awsc-role-display-name" name="displayName" value="${name}"
                 title="${item.role_name}@${item.aws_account_id}" style="white-space:pre"></form>
         </li>`);
@@ -220,7 +220,7 @@ function attachColorLine(profiles) {
 
     var label = usernameMenu.querySelector('.nav-elt-label');
     if (found && found.image) {
-        label.insertAdjacentHTML('beforebegin', Sanitizer.escapeHTML(`<img id="AESW_Image" src=${found.image.replace(/"/g, '')} width="17em" height="17em" style="float: left; padding-right: 1em">`));
+        label.insertAdjacentHTML('beforebegin', Sanitizer.escapeHTML(`<img id="AESW_Image" src=${found.image.replace(/"/g, '')} width="14em" height="14em" style="float: left; padding-right: 1em">`));
     }
 
     if (color) {

--- a/test/content_attach_color_line.test.js
+++ b/test/content_attach_color_line.test.js
@@ -8,6 +8,13 @@ describe('ContentScripts', () => {
         expect(document.getElementById('AESW_ColorLine')).to.exist;
       })
 
+      it('attaches image', () => {
+        loadFixtures('awsmc-iam-switched', 'data');
+        document.querySelector('#nav-usernameMenu .nav-elt-label').textContent = 'a-stg-image';
+        extendIAMFormList();
+        expect(document.getElementById('AESW_Image')).to.exist;
+      })
+
       context('color not defined', () => {
         it('does not attach color line', () => {
           loadFixtures('awsmc-iam-switched', 'data');
@@ -55,12 +62,28 @@ describe('ContentScripts', () => {
         expect(document.getElementById('AESW_ColorLine')).to.exist;
       })
 
+      it('attaches image', () => {
+        loadFixtures('awsmc-federated-switched', 'data');
+        document.querySelector('#nav-usernameMenu .nav-elt-label').textContent = 'b-prod-image';
+        extendIAMFormList();
+        expect(document.getElementById('AESW_Image')).to.exist;
+      })
+
       context('color not defined', () => {
         it('does not attach color line', () => {
           loadFixtures('awsmc-federated-switched', 'data');
           document.querySelector('#nav-usernameMenu .nav-elt-label').textContent = 'b-renpou';
           extendIAMFormList();
           expect(document.getElementById('AESW_ColorLine')).to.be.null;
+        })
+      })
+
+      context('image not defined', () => {
+        it('does not attach image', () => {
+          loadFixtures('awsmc-federated-switched', 'data');
+          document.querySelector('#nav-usernameMenu .nav-elt-label').textContent = 'b-renpou';
+          extendIAMFormList();
+          expect(document.getElementById('AESW_Image')).to.be.null;
         })
       })
     })
@@ -89,6 +112,15 @@ describe('ContentScripts', () => {
         document.querySelector('#nav-usernameMenu .nav-elt-label').textContent = 'other  |  000000000000';
         extendIAMFormList();
         expect(document.getElementById('AESW_ColorLine')).to.be.null;
+      })
+    })
+
+    context('profile not found', () => {
+      it('does not attach icon', () => {
+        loadFixtures('awsmc-federated-switched', 'data');
+        document.querySelector('#nav-usernameMenu .nav-elt-label').textContent = 'other  |  000000000000';
+        extendIAMFormList();
+        expect(document.getElementById('AESW_Image')).to.be.null;
       })
     })
   })

--- a/test/content_redirect_uri.test.js
+++ b/test/content_redirect_uri.test.js
@@ -21,7 +21,7 @@ describe('Reset the region of redirect_uri on content script', () => {
       expect(document.body.className.includes('user-type-federated')).to.be.false;
 
       const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-      expect(roles.length).to.eq(4);
+      expect(roles.length).to.eq(5);
       expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('prod-role');
       expect(roles[3].querySelector('input[type="submit"]').value).to.eq('a-prod  |  555511114444');
 
@@ -39,7 +39,7 @@ describe('Reset the region of redirect_uri on content script', () => {
       expect(document.body.className.includes('user-type-federated')).to.be.false;
 
       const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-      expect(roles.length).to.eq(4);
+      expect(roles.length).to.eq(5);
       expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
       expect(roles[2].querySelector('input[type="submit"]').value).to.eq('a-stg  |  555511113333');
 

--- a/test/content_reset_region.test.js
+++ b/test/content_reset_region.test.js
@@ -21,7 +21,7 @@ describe('Content redirect_uri', () => {
       expect(document.body.className.includes('user-type-federated')).to.be.false;
 
       const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-      expect(roles.length).to.eq(4);
+      expect(roles.length).to.eq(5);
       expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('prod-role');
       expect(roles[3].querySelector('input[type="submit"]').value).to.eq('a-prod  |  555511114444');
 
@@ -39,7 +39,7 @@ describe('Content redirect_uri', () => {
       expect(document.body.className.includes('user-type-federated')).to.be.false;
 
       const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-      expect(roles.length).to.eq(4);
+      expect(roles.length).to.eq(5);
       expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
       expect(roles[2].querySelector('input[type="submit"]').value).to.eq('a-stg  |  555511113333');
 

--- a/test/content_scripts.test.js
+++ b/test/content_scripts.test.js
@@ -104,7 +104,7 @@ describe('ContentScripts', () => {
           expect(roles[3].querySelector('input[type="submit"]').value).to.eq('b-prod  |  666611114444');
           expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('renpou');
           expect(roles[4].querySelector('input[type="submit"]').value).to.eq('b-renpou  |  666611115555');
-          expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('prod-role');
+          expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('prod-role-image');
           expect(roles[5].querySelector('input[type="submit"]').value).to.eq('b-prod-image  |  666611114444');
         })
       })
@@ -160,7 +160,7 @@ describe('ContentScripts', () => {
         expect(roles[7].querySelector('input[type="submit"]').value).to.eq('b-prod  |  666611114444');
         expect(roles[8].querySelector('input[name="roleName"]').value).to.eq('renpou');
         expect(roles[8].querySelector('input[type="submit"]').value).to.eq('b-renpou  |  666611115555');
-        expect(roles[9].querySelector('input[name="roleName"]').value).to.eq('prod-role');
+        expect(roles[9].querySelector('input[name="roleName"]').value).to.eq('prod-role-image');
         expect(roles[9].querySelector('input[type="submit"]').value).to.eq('b-prod-image  |  666611114444');
       })
     })
@@ -186,7 +186,7 @@ describe('ContentScripts', () => {
         expect(roles[3].querySelector('input[type="submit"]').value).to.eq('b-prod  |  666611114444');
         expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('renpou');
         expect(roles[4].querySelector('input[type="submit"]').value).to.eq('b-renpou  |  666611115555');
-        expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('prod-role');
+        expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('prod-role-image');
         expect(roles[5].querySelector('input[type="submit"]').value).to.eq('b-prod-image  |  666611114444');
       })
     })
@@ -279,7 +279,7 @@ describe('ContentScripts', () => {
           expect(roles[3].querySelector('input[type="submit"]').value).to.eq('b-prod  |  666611114444');
           expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('renpou');
           expect(roles[4].querySelector('input[type="submit"]').value).to.eq('b-renpou  |  666611115555');
-          expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('prod-role');
+          expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('prod-role-image');
           expect(roles[5].querySelector('input[type="submit"]').value).to.eq('b-prod-image  |  666611114444');
         })
       })

--- a/test/content_scripts.test.js
+++ b/test/content_scripts.test.js
@@ -72,13 +72,15 @@ describe('ContentScripts', () => {
           expect(document.body.className.includes('user-type-federated')).to.be.false;
 
           const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-          expect(roles.length).to.eq(4);
+          expect(roles.length).to.eq(5);
           expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
           expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
           expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
           expect(roles[2].querySelector('input[type="submit"]').value).to.eq('a-stg  |  555511113333');
           expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('prod-role');
           expect(roles[3].querySelector('input[type="submit"]').value).to.eq('a-prod  |  555511114444');
+          expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('stg-role-image');
+          expect(roles[4].querySelector('input[type="submit"]').value).to.eq('a-stg-image  |  555511113333');
         })
       })
 
@@ -93,7 +95,7 @@ describe('ContentScripts', () => {
           expect(document.body.className.includes('user-type-federated')).to.be.false;
 
           const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-          expect(roles.length).to.eq(5);
+          expect(roles.length).to.eq(6);
           expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
           expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
           expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
@@ -102,6 +104,8 @@ describe('ContentScripts', () => {
           expect(roles[3].querySelector('input[type="submit"]').value).to.eq('b-prod  |  666611114444');
           expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('renpou');
           expect(roles[4].querySelector('input[type="submit"]').value).to.eq('b-renpou  |  666611115555');
+          expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('prod-role');
+          expect(roles[5].querySelector('input[type="submit"]').value).to.eq('b-prod-image  |  666611114444');
         })
       })
     })
@@ -119,7 +123,7 @@ describe('ContentScripts', () => {
           expect(document.body.className.includes('user-type-federated')).to.be.false;
 
           const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-          expect(roles.length).to.eq(5);
+          expect(roles.length).to.eq(6);
           expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
           expect(roles[0].querySelector('input[type="submit"]').value).to.eq('independence');
           expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
@@ -130,6 +134,8 @@ describe('ContentScripts', () => {
           expect(roles[3].querySelector('input[type="submit"]').value).to.eq('b-prod');
           expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('renpou');
           expect(roles[4].querySelector('input[type="submit"]').value).to.eq('b-renpou');
+          expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('prod-role');
+          expect(roles[5].querySelector('input[type="submit"]').value).to.eq('b-prod-image');
         })
       })
     })
@@ -145,7 +151,7 @@ describe('ContentScripts', () => {
         expect(document.body.className.includes('user-type-federated')).to.be.false;
 
         const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-        expect(roles.length).to.eq(9);
+        expect(roles.length).to.eq(10);
         expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
         expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('independence_role');
         expect(roles[6].querySelector('input[name="roleName"]').value).to.eq('stg-role');
@@ -154,6 +160,8 @@ describe('ContentScripts', () => {
         expect(roles[7].querySelector('input[type="submit"]').value).to.eq('b-prod  |  666611114444');
         expect(roles[8].querySelector('input[name="roleName"]').value).to.eq('renpou');
         expect(roles[8].querySelector('input[type="submit"]').value).to.eq('b-renpou  |  666611115555');
+        expect(roles[9].querySelector('input[name="roleName"]').value).to.eq('prod-role');
+        expect(roles[9].querySelector('input[type="submit"]').value).to.eq('b-prod-image  |  666611114444');
       })
     })
 
@@ -169,7 +177,7 @@ describe('ContentScripts', () => {
         expect(document.body.className.includes('user-type-federated')).to.be.false;
 
         const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-        expect(roles.length).to.eq(5);
+        expect(roles.length).to.eq(6);
         expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
         expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
         expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
@@ -178,6 +186,8 @@ describe('ContentScripts', () => {
         expect(roles[3].querySelector('input[type="submit"]').value).to.eq('b-prod  |  666611114444');
         expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('renpou');
         expect(roles[4].querySelector('input[type="submit"]').value).to.eq('b-renpou  |  666611115555');
+        expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('prod-role');
+        expect(roles[5].querySelector('input[type="submit"]').value).to.eq('b-prod-image  |  666611114444');
       })
     })
   })
@@ -237,13 +247,15 @@ describe('ContentScripts', () => {
           expect(document.body.className.includes('user-type-iam')).to.be.false;
 
           const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-          expect(roles.length).to.eq(4);
+          expect(roles.length).to.eq(5);
           expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
           expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
           expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
           expect(roles[2].querySelector('input[type="submit"]').value).to.eq('a-stg  |  555511113333');
           expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('prod-role');
           expect(roles[3].querySelector('input[type="submit"]').value).to.eq('a-prod  |  555511114444');
+          expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('stg-role-image');
+          expect(roles[4].querySelector('input[type="submit"]').value).to.eq('a-stg-image  |  555511113333');
         })
       })
 
@@ -258,7 +270,7 @@ describe('ContentScripts', () => {
           expect(document.body.className.includes('user-type-iam')).to.be.false;
 
           const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-          expect(roles.length).to.eq(5);
+          expect(roles.length).to.eq(6);
           expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
           expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
           expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
@@ -267,6 +279,8 @@ describe('ContentScripts', () => {
           expect(roles[3].querySelector('input[type="submit"]').value).to.eq('b-prod  |  666611114444');
           expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('renpou');
           expect(roles[4].querySelector('input[type="submit"]').value).to.eq('b-renpou  |  666611115555');
+          expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('prod-role');
+          expect(roles[5].querySelector('input[type="submit"]').value).to.eq('b-prod-image  |  666611114444');
         })
       })
     })

--- a/test/content_scripts.test.js
+++ b/test/content_scripts.test.js
@@ -134,7 +134,7 @@ describe('ContentScripts', () => {
           expect(roles[3].querySelector('input[type="submit"]').value).to.eq('b-prod');
           expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('renpou');
           expect(roles[4].querySelector('input[type="submit"]').value).to.eq('b-renpou');
-          expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('prod-role');
+          expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('prod-role-image');
           expect(roles[5].querySelector('input[type="submit"]').value).to.eq('b-prod-image');
         })
       })

--- a/test/content_switched.test.js
+++ b/test/content_switched.test.js
@@ -91,7 +91,7 @@ describe('ContentScripts', () => {
           expect(document.body.className.includes('user-type-iam')).to.be.false;
 
           const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-          expect(roles.length).to.eq(5);
+          expect(roles.length).to.eq(6);
           expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
           expect(roles[0].querySelector('input[type="submit"]').value).to.eq('independence');
           expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
@@ -102,6 +102,8 @@ describe('ContentScripts', () => {
           expect(roles[3].querySelector('input[type="submit"]').value).to.eq('b-prod');
           expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('renpou');
           expect(roles[4].querySelector('input[type="submit"]').value).to.eq('b-renpou');
+          expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('prod-role-image');
+          expect(roles[5].querySelector('input[type="submit"]').value).to.eq('b-prod-image');
         })
       })
     })
@@ -168,7 +170,7 @@ describe('ContentScripts', () => {
           expect(document.body.className.includes('user-type-iam')).to.be.false;
 
           const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-          expect(roles.length).to.eq(5);
+          expect(roles.length).to.eq(6);
           expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
           expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
           expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
@@ -177,6 +179,8 @@ describe('ContentScripts', () => {
           expect(roles[3].querySelector('input[type="submit"]').value).to.eq('b-prod  |  666611114444');
           expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('renpou');
           expect(roles[4].querySelector('input[type="submit"]').value).to.eq('b-renpou  |  666611115555');
+          expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('prod-role-image');
+          expect(roles[5].querySelector('input[type="submit"]').value).to.eq('b-prod-image  |  666611114444');
         })
       })
     })
@@ -193,7 +197,7 @@ describe('ContentScripts', () => {
           expect(document.body.className.includes('user-type-iam')).to.be.false;
 
           const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-          expect(roles.length).to.eq(5);
+          expect(roles.length).to.eq(6);
           expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
           expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
           expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
@@ -202,6 +206,8 @@ describe('ContentScripts', () => {
           expect(roles[3].querySelector('input[type="submit"]').value).to.eq('b-prod  |  666611114444');
           expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('renpou');
           expect(roles[4].querySelector('input[type="submit"]').value).to.eq('b-renpou  |  666611115555');
+          expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('prod-role-image');
+          expect(roles[5].querySelector('input[type="submit"]').value).to.eq('b-prod-image  |  666611114444');
         })
       })
     })

--- a/test/content_switched.test.js
+++ b/test/content_switched.test.js
@@ -20,7 +20,7 @@ describe('ContentScripts', () => {
           expect(document.body.className.includes('user-type-iam')).to.be.false;
 
           const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-          expect(roles.length).to.eq(7);
+          expect(roles.length).to.eq(8);
           expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('stg-role');
           expect(roles[0].querySelector('input[type="submit"]').value).to.eq('a-stg  |  555511113333');
           expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
@@ -63,7 +63,7 @@ describe('ContentScripts', () => {
           expect(document.body.className.includes('user-type-iam')).to.be.false;
 
           const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-          expect(roles.length).to.eq(5);
+          expect(roles.length).to.eq(6);
           expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
           expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
           expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
@@ -72,6 +72,8 @@ describe('ContentScripts', () => {
           expect(roles[3].querySelector('input[type="submit"]').value).to.eq('b-prod  |  666611114444');
           expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('renpou');
           expect(roles[4].querySelector('input[type="submit"]').value).to.eq('b-renpou  |  666611115555');
+          expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('prod-role-image');
+          expect(roles[5].querySelector('input[type="submit"]').value).to.eq('b-prod-image  |  666611114444');
         })
       })
     })

--- a/test/fixtures/data.json
+++ b/test/fixtures/data.json
@@ -4,10 +4,12 @@
     { "profile": "history-contained", "aws_account_id": "111122224444", "role_name": "contained_history_role" },
     { "profile": "base-a", "aws_account_id": "555511112222" },
     { "profile": "a-stg",  "aws_account_id": "555511113333", "role_name": "stg-role", "source_profile": "base-a", "color": "00ddff" },
+    { "profile": "a-stg-image",  "aws_account_id": "555511113333", "role_name": "stg-role", "source_profile": "base-a", "image": "not-found.png" },
     { "profile": "a-prod", "aws_account_id": "555511114444", "role_name": "prod-role", "source_profile": "base-a", "region": "ap-northwest-1" },
     { "profile": "base-b", "aws_account_id": "666611112222" },
     { "profile": "b-stg",  "aws_account_id": "666611113333", "role_name": "stg-role", "source_profile": "base-b" },
     { "profile": "b-prod", "aws_account_id": "666611114444", "role_name": "prod-role", "source_profile": "base-b", "color": "ffcc333" },
+    { "profile": "b-prod-image", "aws_account_id": "666611114444", "role_name": "prod-role", "source_profile": "base-b", "image": "not-found.png" },
     { "profile": "b-renpou", "aws_account_id": "666611115555", "role_name": "renpou", "source_profile": "base-b" }
   ]
 }

--- a/test/fixtures/data.json
+++ b/test/fixtures/data.json
@@ -9,7 +9,7 @@
     { "profile": "b-stg",  "aws_account_id": "666611113333", "role_name": "stg-role", "source_profile": "base-b" },
     { "profile": "b-prod", "aws_account_id": "666611114444", "role_name": "prod-role", "source_profile": "base-b", "color": "ffcc333" },
     { "profile": "b-renpou", "aws_account_id": "666611115555", "role_name": "renpou", "source_profile": "base-b" },
-    { "profile": "a-stg-image",  "aws_account_id": "555511113333", "role_name": "stg-role", "source_profile": "base-a", "image": "not-found.png" },
-    { "profile": "b-prod-image", "aws_account_id": "666611114444", "role_name": "prod-role", "source_profile": "base-b", "image": "not-found.png" }
+    { "profile": "a-stg-image",  "aws_account_id": "555511113333", "role_name": "stg-role-image", "source_profile": "base-a", "image": "not-found.png" },
+    { "profile": "b-prod-image", "aws_account_id": "666611114444", "role_name": "prod-role-image", "source_profile": "base-b", "image": "not-found.png" }
   ]
 }

--- a/test/fixtures/data.json
+++ b/test/fixtures/data.json
@@ -4,12 +4,12 @@
     { "profile": "history-contained", "aws_account_id": "111122224444", "role_name": "contained_history_role" },
     { "profile": "base-a", "aws_account_id": "555511112222" },
     { "profile": "a-stg",  "aws_account_id": "555511113333", "role_name": "stg-role", "source_profile": "base-a", "color": "00ddff" },
-    { "profile": "a-stg-image",  "aws_account_id": "555511113333", "role_name": "stg-role", "source_profile": "base-a", "image": "not-found.png" },
     { "profile": "a-prod", "aws_account_id": "555511114444", "role_name": "prod-role", "source_profile": "base-a", "region": "ap-northwest-1" },
     { "profile": "base-b", "aws_account_id": "666611112222" },
     { "profile": "b-stg",  "aws_account_id": "666611113333", "role_name": "stg-role", "source_profile": "base-b" },
     { "profile": "b-prod", "aws_account_id": "666611114444", "role_name": "prod-role", "source_profile": "base-b", "color": "ffcc333" },
-    { "profile": "b-prod-image", "aws_account_id": "666611114444", "role_name": "prod-role", "source_profile": "base-b", "image": "not-found.png" },
-    { "profile": "b-renpou", "aws_account_id": "666611115555", "role_name": "renpou", "source_profile": "base-b" }
+    { "profile": "b-renpou", "aws_account_id": "666611115555", "role_name": "renpou", "source_profile": "base-b" },
+    { "profile": "a-stg-image",  "aws_account_id": "555511113333", "role_name": "stg-role", "source_profile": "base-a", "image": "not-found.png" },
+    { "profile": "b-prod-image", "aws_account_id": "666611114444", "role_name": "prod-role", "source_profile": "base-b", "image": "not-found.png" }
   ]
 }


### PR DESCRIPTION
Added the ability to include images in addition to colors for each switch role link. The image is also included in the header bar of the console.  Images are set by adding image = <url> to each profile config entry. It does mean that each image must be either served by a local web server or are otherwise online.  