### PR TITLE
Extension API for Config sender

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ The 'Show only matching roles' setting is for use with more sophisticated accoun
 - **Show only matching roles** filters to only show profiles with roles that match your role in your master account.
 - **Automatically assume last assumed role (Experimental)** automatically assumes last assumed role on the next sign-in if did not back to the base account and signed out.
 
+## Extension API
+
+- **Config sender extension** allowed by the **ID** can send your switch roles configuration to this extension. [See](https://github.com/tilfin/aws-extend-switch-roles/wiki/External-API#config-sender-extension) how to make your config sender extension.
+
 ## Donation
 
 Would you like to support this extension? I gladly accept small donations.

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -9,6 +9,7 @@ mkdir -p dist/firefox/js
 content=dist/chrome/js/content.js
 options=dist/chrome/js/options.js
 popup=dist/chrome/js/popup.js
+background=dist/chrome/js/background.js
 
 cat src/lib/common.js                  > $content
 cat src/lib/auto_assume_last_role.js  >> $content
@@ -25,9 +26,15 @@ cat src/options.js                    >> $options
 
 cat src/popup.js                       > $popup
 
-\cp -f $content dist/firefox/js/content.js
-\cp -f $options dist/firefox/js/options.js
-\cp -f $popup   dist/firefox/js/popup.js
+cat src/lib/data_profiles_splitter.js  > $background
+cat src/lib/load_aws_config.js        >> $background
+cat src/lib/lz-string.min.js          >> $background
+cat src/background.js                 >> $background
+
+\cp -f $content    dist/firefox/js/content.js
+\cp -f $options    dist/firefox/js/options.js
+\cp -f $popup      dist/firefox/js/popup.js
+\cp -f $background dist/firefox/js/background.js
 
 \cp -f manifest.json dist/chrome/
 jq -s '.[0] * .[1]' manifest.json manifest_firefox.json > dist/firefox/manifest.json

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "AWS Extend Switch Roles",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "Extend your AWS IAM switching roles. You can set the configuration like aws config format",
   "short_name": "Extend SwitchRole",
   "permissions": ["storage"],
@@ -37,5 +37,11 @@
   "web_accessible_resources": [
     "js/csrf-setter.js"
   ],
+  "background": {
+    "scripts": [
+      "js/background.js"
+    ],
+    "persistent": false
+  },
   "manifest_version": 2
 }

--- a/manifest_firefox.json
+++ b/manifest_firefox.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.13.1",
+  "version": "0.14.0",
   "applications": {
     "gecko": {
       "id": "aws-extend-switch-roles@toshi.tilfin.com",

--- a/options.html
+++ b/options.html
@@ -43,6 +43,11 @@ a { text-decoration: none }
   font-weight: bold;
   margin: 5px 0;
 }
+#settingPane h1 {
+  font-size: 20px;
+  line-height: 1.125;
+  margin: 1em 0 .68em;
+}
 #settings ul {
   list-style: none;
   margin: 0 0; padding: 0;
@@ -110,6 +115,13 @@ code {
     <li><label for="showOnlyMatchingRolesCheckBox"><input type="checkbox" id="showOnlyMatchingRolesCheckBox">Show only matching roles</label></li>
     <li><label for="autoAssumeLastRoleCheckBox"><input type="checkbox" id="autoAssumeLastRoleCheckBox">Automatically assume last assumed role</label> (Experimental) </li>
   </ul>
+ </section>
+ <section id="api">
+  <h1>Extension API</h1>
+  <div>
+   <label for="configSenderIdText">Config sender extension ID:</label>
+   <input id="configSenderIdText" type="text" maxlength="48" style="width: 48ex">
+  </div>
  </section>
 </div>
 <div class="pane" id="howto">
@@ -205,6 +217,12 @@ source_profile = Org2-BaseAccount
    <li><b>Hide account id</b> hides the account_id for each profile.</li>
    <li><b>Show only matching roles</b> filters to only show profiles with roles that match your role in your master account.</li>
    <li><b>Automatically assume last assumed role (Experimental)</b> automatically assumes last assumed role on the next sign-in if did not back to the base account and signed out.</li>
+  </ul>
+ </section>
+ <section>
+  <h3>Extension API</h3>
+  <ul>
+   <li><b>Config sender extension</b> allowed by the **ID** can send your switch roles configuration to this extension. <a href="https://github.com/tilfin/aws-extend-switch-roles/wiki/External-API#config-sender-extension" target="_blank" rel="noopener noreferrer">See</a> how to make your config sender extension.</li>
   </ul>
  </section>
 </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-extend-switch-roles",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "Extend your AWS IAM switching roles by Chrome extension",
   "main": "index.js",
   "directories": {

--- a/src/background.js
+++ b/src/background.js
@@ -1,0 +1,60 @@
+function saveAwsConfig(data, callback) {
+  const rawstr = data;
+
+  try {
+    const profiles = loadAwsConfig(rawstr);
+    if (profiles.length > 200) {
+      callback({
+        result: 'failure',
+        error: {
+          message: 'The number of profiles exceeded maximum 200.'
+        }
+      });
+      return;
+    }
+
+    const dps = new DataProfilesSplitter();
+    const dataSet = dps.profilesToDataSet(profiles);
+    dataSet.lztext = LZString.compressToUTF16(rawstr);
+
+    chrome.storage.sync.set(dataSet,
+      function() {
+        callback({ result: 'success' });
+      });
+  } catch (e) {
+    callback({
+      result: 'failure',
+      error: {
+        message: e.message
+      }
+    });
+  }
+}
+
+chrome.runtime.onMessageExternal.addListener(function (message, sender, sendResponse) {
+  const { action, dataType, data } = message || {};
+  if (!action || !dataType || !data) return;
+
+  if (action !== 'updateConfig') {
+    sendResponse({
+      result: 'failure',
+      error: { message: 'Invalid action' }
+    });
+    return;
+  }
+
+  if (dataType !== 'ini') {
+    sendResponse({
+      result: 'failure',
+      error: { message: 'Invalid dataType' }
+    });
+    return;
+  }
+
+  chrome.storage.sync.get(['configSenderId'], function(settings) {
+    const configSenderIds = (settings.configSenderId || '').split(',');
+    if (configSenderIds.includes(sender.id)) {
+      saveAwsConfig(data, sendResponse)
+    }
+  })
+})

--- a/src/options.js
+++ b/src/options.js
@@ -66,7 +66,11 @@ window.onload = function() {
     }
   }
 
-  chrome.storage.sync.get(['lztext'].concat(booleanSettings), function(data) {
+  elById('configSenderIdText').onchange = function() {
+    chrome.storage.sync.set({ configSenderId: this.value });
+  }
+
+  chrome.storage.sync.get(['lztext', 'configSenderId'].concat(booleanSettings), function(data) {
     let rawData = localStorage['rawdata'];
     if (data.lztext) {
       try {
@@ -76,6 +80,7 @@ window.onload = function() {
       }
     }
     textArea.value = rawData || '';
+    elById('configSenderIdText').value = data.configSenderId || '';
     for (let key of booleanSettings) {
       elById(`${key}CheckBox`).checked = data[key] || false;
     }


### PR DESCRIPTION
#39 

#### Config sender example
```js
  const AESR_ExtensionId = "abcdefefghijkaoahabieaijpdohfocjbphlpf";

  const rawIniStr = `
[profile marketingadmin]
role_arn = arn:aws:iam::123456789012:role/marketingadmin
color = ffaaee

[anotheraccount]
aws_account_id = 987654321987
role_name = anotherrole
region=ap-northeast-1

[athirdaccount]
aws_account_id = 987654321988
role_name = athirdrole
image = "https://via.placeholder.com/150"
`;

  chrome.runtime.sendMessage(AESR_ExtensionId, {
      action: 'updateConfig',
      dataType: 'ini',
      data: rawIniStr
    }, function(response) {});
```
