### PR TITLE
Add second column to account list

### DIFF
--- a/options.html
+++ b/options.html
@@ -110,6 +110,7 @@ code {
  <section id="settings">
   <h1>Settings</h1>
   <ul>
+    <li><label for="useColumnsCheckBox"><input type="checkbox" id="useColumnsCheckBox">Use columns</label></li>
     <li><label for="hidesHistoryCheckBox"><input type="checkbox" id="hidesHistoryCheckBox">Hide original role history</label></li>
     <li><label for="hidesAccountIdCheckBox"><input type="checkbox" id="hidesAccountIdCheckBox">Hide account id</label></li>
     <li><label for="showOnlyMatchingRolesCheckBox"><input type="checkbox" id="showOnlyMatchingRolesCheckBox">Show only matching roles</label></li>
@@ -153,7 +154,7 @@ image = "https://via.placeholder.com/150"
   </pre>
  </section>
  <section>
-  <h3>Complex Configuration</h3>  
+  <h3>Complex Configuration</h3>
   <p>More complex configurations involve multiple AWS accounts and/or organizations.</p>
   <ul>
    <li>A profile that has only <code>aws_account_id</code> (without a <code>role_name</code>) is defined as <b>base account</b></li>

--- a/src/lib/content.js
+++ b/src/lib/content.js
@@ -14,9 +14,10 @@ function extendIAMFormList() {
 
   chrome.storage.sync.get([
     'profiles', 'profiles_1', 'profiles_2', 'profiles_3', 'profiles_4',
-    'hidesHistory', 'hidesAccountId', 'showOnlyMatchingRoles',
+    'useColumns', 'hidesHistory', 'hidesAccountId', 'showOnlyMatchingRoles',
     'autoAssumeLastRole', lastRoleKey
   ], function(data) {
+    var useColumns = data.useColumns || false;
     var hidesHistory = data.hidesHistory || false;
     var hidesAccountId = data.hidesAccountId || false;
     var showOnlyMatchingRoles = data.showOnlyMatchingRoles || false;
@@ -26,7 +27,7 @@ function extendIAMFormList() {
       const dps = new DataProfilesSplitter();
       const profiles = dps.profilesFromDataSet(data);
 
-      loadProfiles(new ProfileSet(profiles, showOnlyMatchingRoles), list, csrf, hidesHistory, hidesAccountId);
+      loadProfiles(new ProfileSet(profiles, showOnlyMatchingRoles), list, csrf, hidesHistory, hidesAccountId, useColumns);
       attachColorLine(profiles);
     }
     // console.log("Last role from '"+vlastRoleKey+"' was '"+lastRole+"'");
@@ -68,7 +69,7 @@ function replaceRedirectURI(form, profile) {
       }
     }
     form.redirect_uri.value = encodeURIComponent(redirectUri);
-  }  
+  }
 }
 
 function hookBeforeSwitch(form, profile) {
@@ -82,7 +83,7 @@ function hookBeforeExit() {
   return true;
 }
 
-function loadProfiles(profileSet, list, csrf, hidesHistory, hidesAccountId) {
+function loadProfiles(profileSet, list, csrf, hidesHistory, hidesAccountId, useColumns) {
   var recentNames = [];
 
   if (hidesHistory) {
@@ -205,6 +206,20 @@ function loadProfiles(profileSet, list, csrf, hidesHistory, hidesAccountId) {
     }
   }
 
+  if(useColumns)
+  {
+    // Split into columns
+    document.getElementById('awsc-username-menu-recent-roles').style.webkitColumns = "2";
+    document.getElementById('awsc-username-menu-recent-roles').style.setProperty("-moz-columns", "2")
+    document.getElementById('awsc-username-menu-recent-roles').style.columns = "2";
+    document.getElementById('awsc-username-menu-recent-roles').style.paddingLeft = "0";
+    document.getElementById('awsc-username-menu-recent-roles').style.listStylePosition = "inside";
+    document.getElementById('awsc-username-menu-recent-roles').style.webkitColumnBreakInside = "avoid";
+    document.getElementById('awsc-username-menu-recent-roles').style.pageBreakInside = "avoid";
+    document.getElementById('awsc-username-menu-recent-roles').style.breakInside = "avoid";
+    document.getElementById('awsc-switch-role').style.marginTop = "1em";
+  }
+
   document.getElementById('nav-usernameMenu').addEventListener('click', () => {
     document.getElementById('AESR_RoleFilter').focus()
   })
@@ -250,4 +265,3 @@ function needsInvertForeColorByBack(color) {
 
   return (0.299 * r + 0.587 * g + 0.114 * b) / 255 < 0.5;
 }
-

--- a/src/lib/content.js
+++ b/src/lib/content.js
@@ -209,15 +209,23 @@ function loadProfiles(profileSet, list, csrf, hidesHistory, hidesAccountId, useC
   if(useColumns)
   {
     // Split into columns
+    document.getElementById('awsc-username-menu-recent-roles').style.display = "block";
     document.getElementById('awsc-username-menu-recent-roles').style.webkitColumns = "2";
     document.getElementById('awsc-username-menu-recent-roles').style.setProperty("-moz-columns", "2")
     document.getElementById('awsc-username-menu-recent-roles').style.columns = "2";
     document.getElementById('awsc-username-menu-recent-roles').style.paddingLeft = "0";
+    document.getElementById('awsc-username-menu-recent-roles').style.webkitColumnGap = "2em";
+    document.getElementById('awsc-username-menu-recent-roles').style.columnGap = "2em";
+    document.getElementById('awsc-username-menu-recent-roles').style.setProperty("-moz-column-gap", "2em")
+    document.getElementById('awsc-username-menu-recent-roles').style.columnRule = "thin solid #cccccc";
+    document.getElementById('awsc-username-menu-recent-roles').style.webkitColumnRule = "thin solid #cccccc";
+    document.getElementById('awsc-username-menu-recent-roles').style.setProperty("-moz-column-rule", "thin solid #cccccc")
     document.getElementById('awsc-username-menu-recent-roles').style.listStylePosition = "inside";
     document.getElementById('awsc-username-menu-recent-roles').style.webkitColumnBreakInside = "avoid";
     document.getElementById('awsc-username-menu-recent-roles').style.pageBreakInside = "avoid";
     document.getElementById('awsc-username-menu-recent-roles').style.breakInside = "avoid";
-    document.getElementById('awsc-switch-role').style.marginTop = "1em";
+    document.getElementById('awsc-username-menu-recent-roles').style.marginTop = "1em";
+    document.getElementById('awsc-username-menu-recent-roles').style.marginBottom = "1em";
   }
 
   document.getElementById('nav-usernameMenu').addEventListener('click', () => {

--- a/src/lib/content.js
+++ b/src/lib/content.js
@@ -209,23 +209,23 @@ function loadProfiles(profileSet, list, csrf, hidesHistory, hidesAccountId, useC
   if(useColumns)
   {
     // Split into columns
-    document.getElementById('awsc-username-menu-recent-roles').style.display = "block";
-    document.getElementById('awsc-username-menu-recent-roles').style.webkitColumns = "2";
-    document.getElementById('awsc-username-menu-recent-roles').style.setProperty("-moz-columns", "2")
-    document.getElementById('awsc-username-menu-recent-roles').style.columns = "2";
-    document.getElementById('awsc-username-menu-recent-roles').style.paddingLeft = "0";
-    document.getElementById('awsc-username-menu-recent-roles').style.webkitColumnGap = "2em";
-    document.getElementById('awsc-username-menu-recent-roles').style.columnGap = "2em";
-    document.getElementById('awsc-username-menu-recent-roles').style.setProperty("-moz-column-gap", "2em")
-    document.getElementById('awsc-username-menu-recent-roles').style.columnRule = "thin solid #cccccc";
-    document.getElementById('awsc-username-menu-recent-roles').style.webkitColumnRule = "thin solid #cccccc";
-    document.getElementById('awsc-username-menu-recent-roles').style.setProperty("-moz-column-rule", "thin solid #cccccc")
-    document.getElementById('awsc-username-menu-recent-roles').style.listStylePosition = "inside";
-    document.getElementById('awsc-username-menu-recent-roles').style.webkitColumnBreakInside = "avoid";
-    document.getElementById('awsc-username-menu-recent-roles').style.pageBreakInside = "avoid";
-    document.getElementById('awsc-username-menu-recent-roles').style.breakInside = "avoid";
-    document.getElementById('awsc-username-menu-recent-roles').style.marginTop = "1em";
-    document.getElementById('awsc-username-menu-recent-roles').style.marginBottom = "1em";
+    document.getElementById('awsc-username-menu-recent-roles').style.display = 'block';
+    document.getElementById('awsc-username-menu-recent-roles').style.webkitColumns = '2';
+    document.getElementById('awsc-username-menu-recent-roles').style.setProperty('-moz-columns', '2')
+    document.getElementById('awsc-username-menu-recent-roles').style.columns = '2';
+    document.getElementById('awsc-username-menu-recent-roles').style.paddingLeft = '0';
+    document.getElementById('awsc-username-menu-recent-roles').style.webkitColumnGap = '2em';
+    document.getElementById('awsc-username-menu-recent-roles').style.columnGap = '2em';
+    document.getElementById('awsc-username-menu-recent-roles').style.setProperty('-moz-column-gap', '2em')
+    document.getElementById('awsc-username-menu-recent-roles').style.columnRule = 'thin solid #cccccc';
+    document.getElementById('awsc-username-menu-recent-roles').style.webkitColumnRule = 'thin solid #cccccc';
+    document.getElementById('awsc-username-menu-recent-roles').style.setProperty('-moz-column-rule', 'thin solid #cccccc')
+    document.getElementById('awsc-username-menu-recent-roles').style.listStylePosition = 'inside';
+    document.getElementById('awsc-username-menu-recent-roles').style.webkitColumnBreakInside = 'avoid';
+    document.getElementById('awsc-username-menu-recent-roles').style.pageBreakInside = 'avoid';
+    document.getElementById('awsc-username-menu-recent-roles').style.breakInside = 'avoid';
+    document.getElementById('awsc-username-menu-recent-roles').style.marginTop = '1em';
+    document.getElementById('awsc-username-menu-recent-roles').style.marginBottom = '1em';
   }
 
   document.getElementById('nav-usernameMenu').addEventListener('click', () => {

--- a/src/options.js
+++ b/src/options.js
@@ -59,7 +59,7 @@ window.onload = function() {
     }
   }
 
-  const booleanSettings = ['hidesHistory', 'hidesAccountId', 'showOnlyMatchingRoles', 'autoAssumeLastRole'];
+  const booleanSettings = ['useColumns', 'hidesHistory', 'hidesAccountId', 'showOnlyMatchingRoles', 'autoAssumeLastRole'];
   for (let key of booleanSettings) {
     elById(`${key}CheckBox`).onchange = function() {
       chrome.storage.sync.set({ [key]: this.checked });

--- a/test/content_scripts.test.js
+++ b/test/content_scripts.test.js
@@ -130,6 +130,48 @@ describe('ContentScripts', () => {
       })
     })
 
+    context('hidesHistory and usesColumns', () => {
+      context('base profile is undefined', () => {
+        it('hides histories and appends 2 roles and uses columns', () => {
+          loadFixtures('awsmc-iam', 'data');
+          chrome.storage.sync.data.hidesHistory = true;
+          extendIAMFormList();
+
+          expect(document.body.className.includes('user-type-iam')).to.be.true;
+          expect(document.body.className.includes('user-type-federated')).to.be.false;
+
+          const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
+          expect(roles.length).to.eq(2);
+          expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
+          expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
+        })
+      })
+
+      context('base-a profile', () => {
+        it('hides histories and appends 4 roles', () => {
+          loadFixtures('awsmc-iam', 'data');
+          document.getElementById('awsc-login-display-name-account').textContent = '5555-1111-2222';
+          chrome.storage.sync.data.hidesHistory = true;
+          chrome.storage.sync.data.usesColumns = true;
+          extendIAMFormList();
+
+          expect(document.body.className.includes('user-type-iam')).to.be.true;
+          expect(document.body.className.includes('user-type-federated')).to.be.false;
+
+          const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
+          expect(roles.length).to.eq(5);
+          expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
+          expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
+          expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
+          expect(roles[2].querySelector('input[type="submit"]').value).to.eq('a-stg  |  555511113333');
+          expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('prod-role');
+          expect(roles[3].querySelector('input[type="submit"]').value).to.eq('a-prod  |  555511114444');
+          expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('stg-role-image');
+          expect(roles[4].querySelector('input[type="submit"]').value).to.eq('a-stg-image  |  555511113333');
+        })
+      })
+    })
+
     context('hidesHistory and hidesAccountId', () => {
       context('base-b profile', () => {
         it('hides account id', () => {
@@ -363,7 +405,7 @@ describe('ContentScripts', () => {
         expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('renpou');
       })
     })
-    
+
     context('including the AccountId in Search', () => {
       it('appends 3 roles then filter', () => {
         loadFixtures('awsmc-federated', 'data');
@@ -372,14 +414,14 @@ describe('ContentScripts', () => {
         chrome.storage.sync.data.hidesAccountId = false;
         chrome.storage.sync.data.showOnlyMatchingRoles = true;
         extendIAMFormList();
-        
-        const filter = document.querySelector('#AESR_RoleFilter')      
+
+        const filter = document.querySelector('#AESR_RoleFilter')
         filter.value = "666611115555"
         filter.dispatchEvent(new KeyboardEvent('keyup',{'key':'5'}))
 
         const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li[style*="display: block;"]'))
         expect(roles.length).to.eq(1);
-        expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('renpou');        
+        expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('renpou');
       })
     })
 
@@ -391,14 +433,14 @@ describe('ContentScripts', () => {
         chrome.storage.sync.data.hidesAccountId = true;
         chrome.storage.sync.data.showOnlyMatchingRoles = true;
         extendIAMFormList();
-        
-        const filter = document.querySelector('#AESR_RoleFilter')      
+
+        const filter = document.querySelector('#AESR_RoleFilter')
         filter.value = "666611115555"
         filter.dispatchEvent(new KeyboardEvent('keyup',{'key':'5'}))
 
         const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li[style*="display: block;"]'))
         expect(roles.length).to.eq(0);
       })
-    })    
+    })
   })
 })

--- a/test/content_scripts.test.js
+++ b/test/content_scripts.test.js
@@ -130,48 +130,6 @@ describe('ContentScripts', () => {
       })
     })
 
-    context('hidesHistory and usesColumns', () => {
-      context('base profile is undefined', () => {
-        it('hides histories and appends 2 roles and uses columns', () => {
-          loadFixtures('awsmc-iam', 'data');
-          chrome.storage.sync.data.hidesHistory = true;
-          extendIAMFormList();
-
-          expect(document.body.className.includes('user-type-iam')).to.be.true;
-          expect(document.body.className.includes('user-type-federated')).to.be.false;
-
-          const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-          expect(roles.length).to.eq(2);
-          expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
-          expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
-        })
-      })
-
-      context('base-a profile', () => {
-        it('hides histories and appends 4 roles', () => {
-          loadFixtures('awsmc-iam', 'data');
-          document.getElementById('awsc-login-display-name-account').textContent = '5555-1111-2222';
-          chrome.storage.sync.data.hidesHistory = true;
-          chrome.storage.sync.data.usesColumns = true;
-          extendIAMFormList();
-
-          expect(document.body.className.includes('user-type-iam')).to.be.true;
-          expect(document.body.className.includes('user-type-federated')).to.be.false;
-
-          const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-          expect(roles.length).to.eq(5);
-          expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
-          expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
-          expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
-          expect(roles[2].querySelector('input[type="submit"]').value).to.eq('a-stg  |  555511113333');
-          expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('prod-role');
-          expect(roles[3].querySelector('input[type="submit"]').value).to.eq('a-prod  |  555511114444');
-          expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('stg-role-image');
-          expect(roles[4].querySelector('input[type="submit"]').value).to.eq('a-stg-image  |  555511113333');
-        })
-      })
-    })
-
     context('hidesHistory and hidesAccountId', () => {
       context('base-b profile', () => {
         it('hides account id', () => {

--- a/test/content_switched.test.js
+++ b/test/content_switched.test.js
@@ -78,12 +78,13 @@ describe('ContentScripts', () => {
       })
     })
 
-    context('useColumns', () => {
+    context('usesColumns', () => {
       context('base-a profile', () => {
-        it('appends 4 roles and uses columns', () => {
+        it('hides histories and appends 4 roles and uses columns', () => {
           loadFixtures('awsmc-iam-switched', 'data');
           document.getElementById('awsc-login-display-name-account').textContent = '5555-1111-2222';
-          chrome.storage.sync.data.useColumns = true;
+          chrome.storage.sync.data.hidesHistory = true;
+          chrome.storage.sync.data.usesColumns = true;
           extendIAMFormList();
 
           expect(document.body.className.includes('user-type-federated')).to.be.true;

--- a/test/content_switched.test.js
+++ b/test/content_switched.test.js
@@ -78,7 +78,7 @@ describe('ContentScripts', () => {
       })
     })
 
-    context('usesColumns', () => {
+    context('hidesHistory and usesColumns', () => {
       context('base-a profile', () => {
         it('hides histories and appends 4 roles and uses columns', () => {
           loadFixtures('awsmc-iam-switched', 'data');

--- a/test/content_switched.test.js
+++ b/test/content_switched.test.js
@@ -231,12 +231,68 @@ describe('ContentScripts', () => {
       })
     })
 
+    context('not hidesHistory and usesColumns', () => {
+      context('base-b profile', () => {
+        it('hides histories and appends 5 roles and uses columns', () => {
+          loadFixtures('awsmc-federated-switched', 'data');
+          document.getElementById('awsc-login-display-name-account').textContent = '6666-1111-2222';
+          chrome.storage.sync.data.hidesHistory = true;
+          chrome.storage.sync.data.usesColumns = true;
+          extendIAMFormList();
+
+          expect(document.body.className.includes('user-type-federated')).to.be.true;
+          expect(document.body.className.includes('user-type-iam')).to.be.false;
+
+          const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
+          expect(roles.length).to.eq(6);
+          expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
+          expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
+          expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
+          expect(roles[2].querySelector('input[type="submit"]').value).to.eq('b-stg  |  666611113333');
+          expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('prod-role');
+          expect(roles[3].querySelector('input[type="submit"]').value).to.eq('b-prod  |  666611114444');
+          expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('renpou');
+          expect(roles[4].querySelector('input[type="submit"]').value).to.eq('b-renpou  |  666611115555');
+          expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('prod-role-image');
+          expect(roles[5].querySelector('input[type="submit"]').value).to.eq('b-prod-image  |  666611114444');
+        })
+      })
+    })
+
     context('hidesHistory', () => {
       context('base-b profile', () => {
         it('hides histories and appends 5 roles', () => {
           loadFixtures('awsmc-federated-switched', 'data');
           document.getElementById('awsc-login-display-name-account').textContent = '6666-1111-2222';
           chrome.storage.sync.data.hidesHistory = true;
+          extendIAMFormList();
+
+          expect(document.body.className.includes('user-type-federated')).to.be.true;
+          expect(document.body.className.includes('user-type-iam')).to.be.false;
+
+          const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
+          expect(roles.length).to.eq(6);
+          expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
+          expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
+          expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
+          expect(roles[2].querySelector('input[type="submit"]').value).to.eq('b-stg  |  666611113333');
+          expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('prod-role');
+          expect(roles[3].querySelector('input[type="submit"]').value).to.eq('b-prod  |  666611114444');
+          expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('renpou');
+          expect(roles[4].querySelector('input[type="submit"]').value).to.eq('b-renpou  |  666611115555');
+          expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('prod-role-image');
+          expect(roles[5].querySelector('input[type="submit"]').value).to.eq('b-prod-image  |  666611114444');
+        })
+      })
+    })
+
+    context('hidesHistory and usesColumns', () => {
+      context('base-b profile', () => {
+        it('hides histories and appends 5 roles and uses columns', () => {
+          loadFixtures('awsmc-federated-switched', 'data');
+          document.getElementById('awsc-login-display-name-account').textContent = '6666-1111-2222';
+          chrome.storage.sync.data.hidesHistory = true;
+          chrome.storage.sync.data.usesColumns = true;
           extendIAMFormList();
 
           expect(document.body.className.includes('user-type-federated')).to.be.true;

--- a/test/content_switched.test.js
+++ b/test/content_switched.test.js
@@ -78,6 +78,29 @@ describe('ContentScripts', () => {
       })
     })
 
+    context('not hidesHistory and usesColumns', () => {
+      context('base-a profile', () => {
+        it('appends 4 roles but two of them already exist and uses columns', () => {
+          loadFixtures('awsmc-iam-switched', 'data');
+          document.getElementById('awsc-login-display-name-account').textContent = '5555-1111-2222';
+          chrome.storage.sync.data.usesColumns = true;
+          extendIAMFormList();
+
+          expect(document.body.className.includes('user-type-federated')).to.be.true;
+          expect(document.body.className.includes('user-type-iam')).to.be.false;
+
+          const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
+          expect(roles.length).to.eq(8);
+          expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('stg-role');
+          expect(roles[0].querySelector('input[type="submit"]').value).to.eq('a-stg  |  555511113333');
+          expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
+          expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('independence_role');
+          expect(roles[6].querySelector('input[name="roleName"]').value).to.eq('prod-role');
+          expect(roles[6].querySelector('input[type="submit"]').value).to.eq('a-prod  |  555511114444');
+        })
+      })
+    })
+
     context('hidesHistory and usesColumns', () => {
       context('base-a profile', () => {
         it('hides histories and appends 4 roles and uses columns', () => {

--- a/test/content_switched.test.js
+++ b/test/content_switched.test.js
@@ -9,28 +9,6 @@ describe('ContentScripts', () => {
       expect(document.querySelectorAll('#awsc-username-menu-recent-roles li').length).to.eq(5);
     })
 
-    context('useColumns', () => {
-      context('base-a profile', () => {
-        it('appends 4 roles and uses columns', () => {
-          loadFixtures('awsmc-iam-switched', 'data');
-          document.getElementById('awsc-login-display-name-account').textContent = '5555-1111-2222';
-          chrome.storage.sync.data.useColumns = true;
-          extendIAMFormList();
-
-          expect(document.body.className.includes('user-type-federated')).to.be.true;
-          expect(document.body.className.includes('user-type-iam')).to.be.false;
-
-          const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-          expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
-          expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
-          expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
-          expect(roles[2].querySelector('input[type="submit"]').value).to.eq('a-stg  |  555511113333');
-          expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('prod-role');
-          expect(roles[3].querySelector('input[type="submit"]').value).to.eq('a-prod  |  555511114444');
-        })
-      })
-    })
-
     context('not hidesHistory', () => {
       context('base-a profile', () => {
         it('appends 4 roles but two of them already exist', () => {
@@ -96,6 +74,28 @@ describe('ContentScripts', () => {
           expect(roles[4].querySelector('input[type="submit"]').value).to.eq('b-renpou  |  666611115555');
           expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('prod-role-image');
           expect(roles[5].querySelector('input[type="submit"]').value).to.eq('b-prod-image  |  666611114444');
+        })
+      })
+    })
+
+    context('useColumns', () => {
+      context('base-a profile', () => {
+        it('appends 4 roles and uses columns', () => {
+          loadFixtures('awsmc-iam-switched', 'data');
+          document.getElementById('awsc-login-display-name-account').textContent = '5555-1111-2222';
+          chrome.storage.sync.data.useColumns = true;
+          extendIAMFormList();
+
+          expect(document.body.className.includes('user-type-federated')).to.be.true;
+          expect(document.body.className.includes('user-type-iam')).to.be.false;
+
+          const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
+          expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
+          expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
+          expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
+          expect(roles[2].querySelector('input[type="submit"]').value).to.eq('a-stg  |  555511113333');
+          expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('prod-role');
+          expect(roles[3].querySelector('input[type="submit"]').value).to.eq('a-prod  |  555511114444');
         })
       })
     })

--- a/test/content_switched.test.js
+++ b/test/content_switched.test.js
@@ -9,6 +9,28 @@ describe('ContentScripts', () => {
       expect(document.querySelectorAll('#awsc-username-menu-recent-roles li').length).to.eq(5);
     })
 
+    context('useColumns', () => {
+      context('base-a profile', () => {
+        it('appends 4 roles and uses columns', () => {
+          loadFixtures('awsmc-iam-switched', 'data');
+          document.getElementById('awsc-login-display-name-account').textContent = '5555-1111-2222';
+          chrome.storage.sync.data.useColumns = true;
+          extendIAMFormList();
+
+          expect(document.body.className.includes('user-type-federated')).to.be.true;
+          expect(document.body.className.includes('user-type-iam')).to.be.false;
+
+          const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
+          expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
+          expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
+          expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
+          expect(roles[2].querySelector('input[type="submit"]').value).to.eq('a-stg  |  555511113333');
+          expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('prod-role');
+          expect(roles[3].querySelector('input[type="submit"]').value).to.eq('a-prod  |  555511114444');
+        })
+      })
+    })
+
     context('not hidesHistory', () => {
       context('base-a profile', () => {
         it('appends 4 roles but two of them already exist', () => {


### PR DESCRIPTION
This adds a second column to the account list which can be enabled or disabled on the options page.

I think this solves the problem of too many accounts a bit nicer than adding a scroll bar, although should there be a lot of accounts a scroll bar would also be good.