### PR TITLE
Adding option target_region for base profiles

### DIFF
--- a/src/lib/profile_set.js
+++ b/src/lib/profile_set.js
@@ -43,6 +43,11 @@ class ProfileSet {
       if (!profile.role_name) {
         profile.role_name = baseProfile.target_role_name
       }
+
+      if (!profile.region && baseProfile.target_region) {
+        profile.region = baseProfile.target_region
+      }
+      
       return profile
     })
 

--- a/test/content.test.js
+++ b/test/content.test.js
@@ -59,12 +59,15 @@ describe('Profile', () => {
         { profile: 'targetex', aws_account_id: '333300001112',
           role_name: 'roleex' },
         { profile: 'target4', aws_account_id: '222200001112',
-          role_name: 'role3', source_profile: 'base2' }
+          role_name: 'role3', source_profile: 'base2' },
+        { profile: 'target5', aws_account_id: '333300001113',
+          region: 'OverrideRegion', source_profile: 'base1' }
       ]);
 
       expect(profileSet.destProfiles[0].profile).to.eq('targetex');
       expect(profileSet.destProfiles[1]).to.deep.include({ profile: 'target1', region: 'DefaultRegion' });
       expect(profileSet.destProfiles[2]).to.deep.include({ profile: 'target2', region: 'DefaultRegion' });
+      expect(profileSet.destProfiles[3]).to.deep.include({ profile: 'target5', region: 'OverrideRegion' });
       expect(profileSet.excludedNames[0]).to.eq('target4');
     })
   })

--- a/test/content.test.js
+++ b/test/content.test.js
@@ -47,6 +47,26 @@ describe('Profile', () => {
       expect(profileSet.destProfiles[2]).to.deep.include({ profile: 'target2', role_name: 'DefaultRole' });
       expect(profileSet.excludedNames[0]).to.eq('target4');
     })
+
+    it('loads the configuration that contains base account with target_region', () => {
+      let profileSet = new ProfileSet([
+        { profile: 'target1', aws_account_id: '111122223334',
+          role_name: 'Role1', source_profile: 'base1' },
+        { profile: 'target2', aws_account_id: '111122223335',
+          source_profile: 'base1' },
+        { profile: 'base1', aws_account_id: '111100003333', target_region: 'DefaultRegion' },
+        { profile: 'base2', aws_account_id: '222200001111' },
+        { profile: 'targetex', aws_account_id: '333300001112',
+          role_name: 'roleex' },
+        { profile: 'target4', aws_account_id: '222200001112',
+          role_name: 'role3', source_profile: 'base2' }
+      ]);
+
+      expect(profileSet.destProfiles[0].profile).to.eq('targetex');
+      expect(profileSet.destProfiles[1]).to.deep.include({ profile: 'target1', region: 'DefaultRegion' });
+      expect(profileSet.destProfiles[2]).to.deep.include({ profile: 'target2', region: 'DefaultRegion' });
+      expect(profileSet.excludedNames[0]).to.eq('target4');
+    })
   })
 
   it('load base aws account is alias', () => {


### PR DESCRIPTION
If a `target_region` is specified in a `baseProfile`, then all regions that list it as a `sourceProfile` will automatically use that region.