### PR TITLE
Support AWS China partition(#108)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+## v0.14.1 (2020/01/13)
+
+- Support AWS China Partition
+
 ## v0.14.0 (2019/07/24)
 
 - Support Config sender extension of External API

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "AWS Extend Switch Roles",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Extend your AWS IAM switching roles. You can set the configuration like aws config format",
   "short_name": "Extend SwitchRole",
   "permissions": ["storage"],
@@ -20,7 +20,9 @@
         "https://*.console.aws.amazon.com/*",
         "https://phd.aws.amazon.com/*",
         "https://console.amazonaws-us-gov.com/*",
-        "https://*.console.amazonaws-us-gov.com/*"
+        "https://*.console.amazonaws-us-gov.com/*",
+        "https://console.amazonaws.cn/*",
+        "https://*.console.amazonaws.cn/*"
       ],
       "all_frames": true,
       "js": [

--- a/manifest_firefox.json
+++ b/manifest_firefox.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.14.0",
+  "version": "0.14.1",
   "applications": {
     "gecko": {
       "id": "aws-extend-switch-roles@toshi.tilfin.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-extend-switch-roles",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Extend your AWS IAM switching roles by Chrome extension",
   "main": "index.js",
   "directories": {

--- a/src/lib/content.js
+++ b/src/lib/content.js
@@ -123,7 +123,14 @@ function loadProfiles(profileSet, list, csrf, hidesHistory, hidesAccountId) {
     if (!hidesAccountId) name += '  |  ' + item.aws_account_id;
 
     var color = item.color || 'aaaaaa';
-    var actionHost = window.location.host.endsWith('.amazonaws-us-gov.com') ? 'signin.amazonaws-us-gov.com' : 'signin.aws.amazon.com';
+    let actionHost;
+    if (window.location.host.endsWith('.amazonaws-us-gov.com')) {
+        actionHost = 'signin.amazonaws-us-gov.com';
+    } else if (window.location.host.endsWith('.amazonaws.cn')) {
+        actionHost = 'signin.amazonaws.cn';
+    } else {
+        actionHost = 'signin.aws.amazon.com';
+    }
     if (!item.image) {
         list.insertAdjacentHTML('beforeend', Sanitizer.escapeHTML`<li>
          <form action="https://${actionHost}/switchrole" method="POST" target="_top" data-aesr-profile="${item.profile}">


### PR DESCRIPTION
There are 3 AWS::Partition, currently in AWS, two of which is already supported by the plugin.
Let's add the 3rd as well.
In terms of settings, the domains for the metadata.json are

+	"https://console.amazonaws.cn/*",
+	"https://*.console.amazonaws.cn/*"
And for the content.js the actionHost for China is

signin.amazonaws.cn
and of course the ends-with filter is just

'.amazonaws.cn'