### PR TITLE
Feature/126 firefox tab container support

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -41,6 +41,7 @@ jq -s '.[0] * .[1]' manifest.json manifest_firefox.json > dist/firefox/manifest.
 
 for brw in `ls dist`
 do
+  \cp node_modules/webextension-polyfill/dist/browser-polyfill.js dist/$brw/js/
   \cp src/csrf-setter.js dist/$brw/js/
   \cp src/sanitizer.js dist/$brw/js/
   \cp -r *.html dist/$brw/

--- a/manifest.json
+++ b/manifest.json
@@ -24,6 +24,7 @@
       ],
       "all_frames": true,
       "js": [
+        "js/browser-polyfill.js",
         "js/sanitizer.js",
         "js/content.js"
       ],
@@ -39,6 +40,7 @@
   ],
   "background": {
     "scripts": [
+      "js/browser-polyfill.js",
       "js/background.js"
     ],
     "persistent": false

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "version": "0.14.0",
   "description": "Extend your AWS IAM switching roles. You can set the configuration like aws config format",
   "short_name": "Extend SwitchRole",
-  "permissions": ["storage"],
+  "permissions": ["storage", "cookies"],
   "icons" : {
     "48": "icons/Icon_48x48.png",
     "128": "icons/Icon_128x128.png"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "karma-html2js-preprocessor": "^1.1.0",
     "karma-json-fixtures-preprocessor": "0.0.6",
     "karma-mocha": "^1.3.0",
-    "mocha": "^5.2.0"
+    "mocha": "^5.2.0",
+    "webextension-polyfill": "^0.6.0"
   }
 }

--- a/src/background.js
+++ b/src/background.js
@@ -31,6 +31,15 @@ function saveAwsConfig(data, callback) {
   }
 }
 
+chrome.runtime.onMessage.addListener(async (message, sender) => {
+  console.log(JSON.stringify(message));
+  if (message.action === 'get-current-tab-context') {
+    // const currentTab = await browser.tabs.getCurrentTab();
+    // return currentTab.cookieStoreId || ''
+    return sender.tab.cookieStoreId || '';
+  }
+})
+
 chrome.runtime.onMessageExternal.addListener(function (message, sender, sendResponse) {
   const { action, dataType, data } = message || {};
   if (!action || !dataType || !data) return;

--- a/src/background.js
+++ b/src/background.js
@@ -31,7 +31,7 @@ function saveAwsConfig(data, callback) {
   }
 }
 
-chrome.runtime.onMessage.addListener(async (message, sender) => {
+browser.runtime.onMessage.addListener(async (message, sender) => {
   console.log(JSON.stringify(message));
   if (message.action === 'get-current-tab-context') {
     // const currentTab = await browser.tabs.getCurrentTab();

--- a/src/lib/auto_assume_last_role.js
+++ b/src/lib/auto_assume_last_role.js
@@ -6,7 +6,7 @@ class AutoAssumeLastRole {
   }
 
   setup() { // Promise<void>;
-    return chrome.runtime.sendMessage({ action: "get-current-tab-context" })
+    return browser.runtime.sendMessage({ action: 'get-current-tab-context' })
       .then(tabContext => { this.tabContext = tabContext });
   }
 

--- a/src/lib/auto_assume_last_role.js
+++ b/src/lib/auto_assume_last_role.js
@@ -5,8 +5,9 @@ class AutoAssumeLastRole {
     //   .then(tabContext => this.tabContext = tabContext)  }
   }
 
-  async setup() { // Promise<void>;
-    this.tabContext = await chrome.runtime.sendMessage({ action: "get-current-tab-context" });
+  setup() { // Promise<void>;
+    return chrome.runtime.sendMessage({ action: "get-current-tab-context" })
+      .then(tabContext => { this.tabContext = tabContext });
   }
 
   execute(targetIdRole, list) {

--- a/src/lib/auto_assume_last_role.js
+++ b/src/lib/auto_assume_last_role.js
@@ -7,7 +7,7 @@ class AutoAssumeLastRole {
 
   setup() { // Promise<void>;
     return browser.runtime.sendMessage({ action: 'get-current-tab-context' })
-      .then(tabContext => { this.tabContext = tabContext });
+      .then(tabContext => { this.tabContext = (tabContext) ? `_${tabContext}` : '' });
   }
 
   execute(targetIdRole, list) {

--- a/src/lib/auto_assume_last_role.js
+++ b/src/lib/auto_assume_last_role.js
@@ -1,6 +1,12 @@
 class AutoAssumeLastRole {
   constructor() {
     this.enabled = false;
+    // this.tabContextWaiter = chrome.sendMessage({ action: "get-current-tab-context" }) // Promise<void>;
+    //   .then(tabContext => this.tabContext = tabContext)  }
+  }
+
+  async setup() { // Promise<void>;
+    this.tabContext = await chrome.runtime.sendMessage({ action: "get-current-tab-context" });
   }
 
   execute(targetIdRole, list) {
@@ -41,7 +47,7 @@ class AutoAssumeLastRole {
   createKey() {
     const accountId = getAccountId('awsc-login-display-name-account');
     const user = elById('awsc-login-display-name-user').textContent.trim().replace(/(.*)\/.*/, '$1');
-    return `lastRole_${accountId}_${user}`;
+    return `lastRole_${accountId}_${user}${this.tabContext}`;
   }
 
   hasAssumedRole() {

--- a/src/lib/content.js
+++ b/src/lib/content.js
@@ -1,6 +1,6 @@
 const autoAssumeLastRole = new AutoAssumeLastRole();
 
-async function extendIAMFormList() {
+function extendIAMFormList() {
   var csrf, list = elById('awsc-username-menu-recent-roles');
   if (list) {
     var firstForm = list.querySelector('#awsc-recent-role-0 form');
@@ -11,30 +11,31 @@ async function extendIAMFormList() {
   }
 
   console.log('Before await')
-  await autoAssumeLastRole.setup();
-  console.log('After await')
+  return autoAssumeLastRole.setup().then(() => {
+    console.log('After await')
   
-  const lastRoleKey = autoAssumeLastRole.createKey();
+    const lastRoleKey = autoAssumeLastRole.createKey();
 
-  chrome.storage.sync.get([
-    'profiles', 'profiles_1', 'profiles_2', 'profiles_3', 'profiles_4',
-    'hidesHistory', 'hidesAccountId', 'showOnlyMatchingRoles',
-    'autoAssumeLastRole', lastRoleKey
-  ], function(data) {
-    var hidesHistory = data.hidesHistory || false;
-    var hidesAccountId = data.hidesAccountId || false;
-    var showOnlyMatchingRoles = data.showOnlyMatchingRoles || false;
-    autoAssumeLastRole.enabled = data.autoAssumeLastRole || false;
+    chrome.storage.sync.get([
+      'profiles', 'profiles_1', 'profiles_2', 'profiles_3', 'profiles_4',
+      'hidesHistory', 'hidesAccountId', 'showOnlyMatchingRoles',
+      'autoAssumeLastRole', lastRoleKey
+    ], function(data) {
+      var hidesHistory = data.hidesHistory || false;
+      var hidesAccountId = data.hidesAccountId || false;
+      var showOnlyMatchingRoles = data.showOnlyMatchingRoles || false;
+      autoAssumeLastRole.enabled = data.autoAssumeLastRole || false;
 
-    if (data.profiles) {
-      const dps = new DataProfilesSplitter();
-      const profiles = dps.profilesFromDataSet(data);
+      if (data.profiles) {
+        const dps = new DataProfilesSplitter();
+        const profiles = dps.profilesFromDataSet(data);
 
-      loadProfiles(new ProfileSet(profiles, showOnlyMatchingRoles), list, csrf, hidesHistory, hidesAccountId);
-      attachColorLine(profiles);
-    }
-    // console.log("Last role from '"+vlastRoleKey+"' was '"+lastRole+"'");
-    autoAssumeLastRole.execute(data[lastRoleKey], list);
+        loadProfiles(new ProfileSet(profiles, showOnlyMatchingRoles), list, csrf, hidesHistory, hidesAccountId);
+        attachColorLine(profiles);
+      }
+      // console.log("Last role from '"+vlastRoleKey+"' was '"+lastRole+"'");
+      autoAssumeLastRole.execute(data[lastRoleKey], list);
+    });
   });
 }
 

--- a/src/lib/content.js
+++ b/src/lib/content.js
@@ -1,6 +1,6 @@
 const autoAssumeLastRole = new AutoAssumeLastRole();
 
-function extendIAMFormList() {
+async function extendIAMFormList() {
   var csrf, list = elById('awsc-username-menu-recent-roles');
   if (list) {
     var firstForm = list.querySelector('#awsc-recent-role-0 form');
@@ -10,6 +10,10 @@ function extendIAMFormList() {
     csrf = '';
   }
 
+  console.log('Before await')
+  await autoAssumeLastRole.setup();
+  console.log('After await')
+  
   const lastRoleKey = autoAssumeLastRole.createKey();
 
   chrome.storage.sync.get([

--- a/test/content_attach_color_line.test.js
+++ b/test/content_attach_color_line.test.js
@@ -4,23 +4,23 @@ describe('ContentScripts', () => {
       it('attaches color line', () => {
         loadFixtures('awsmc-iam-switched', 'data');
         document.querySelector('#nav-usernameMenu .nav-elt-label').textContent = 'a-stg';
-        extendIAMFormList();
-        expect(document.getElementById('AESW_ColorLine')).to.exist;
+        return extendIAMFormList().then(() => 
+          expect(document.getElementById('AESW_ColorLine')).to.exist);
       })
 
       it('attaches image', () => {
         loadFixtures('awsmc-iam-switched', 'data');
         document.querySelector('#nav-usernameMenu .nav-elt-label').textContent = 'a-stg-image';
-        extendIAMFormList();
-        expect(document.getElementById('AESW_Image')).to.exist;
+        return extendIAMFormList().then(() => 
+          expect(document.getElementById('AESW_Image')).to.exist);
       })
 
       context('color not defined', () => {
         it('does not attach color line', () => {
           loadFixtures('awsmc-iam-switched', 'data');
           document.querySelector('#nav-usernameMenu .nav-elt-label').textContent = 'a-prod';
-          extendIAMFormList();
-          expect(document.getElementById('AESW_ColorLine')).to.be.null;
+          return extendIAMFormList().then(() => 
+            expect(document.getElementById('AESW_ColorLine')).to.be.null);
         })
       })
     })
@@ -29,16 +29,16 @@ describe('ContentScripts', () => {
       it('attaches color line', () => {
         loadFixtures('awsmc-iam-switched', 'data');
         document.querySelector('#nav-usernameMenu .nav-elt-label').textContent = 'a-stg  |  555511113333';
-        extendIAMFormList();
-        expect(document.getElementById('AESW_ColorLine')).to.exist;
+        return extendIAMFormList().then(() => 
+          expect(document.getElementById('AESW_ColorLine')).to.exist);
       })
 
       context('color not defined', () => {
         it('does not attach color line', () => {
           loadFixtures('awsmc-iam-switched', 'data');
           document.querySelector('#nav-usernameMenu .nav-elt-label').textContent = 'a-prod  |  555511114444';
-          extendIAMFormList();
-          expect(document.getElementById('AESW_ColorLine')).to.be.null;
+          return extendIAMFormList().then(() => 
+            expect(document.getElementById('AESW_ColorLine')).to.be.null);
         })
       })
     })
@@ -47,8 +47,8 @@ describe('ContentScripts', () => {
       it('does not attach color line', () => {
           loadFixtures('awsmc-iam-switched', 'data');
         document.querySelector('#nav-usernameMenu .nav-elt-label').textContent = 'other';
-        extendIAMFormList();
-        expect(document.getElementById('AESW_ColorLine')).to.be.null;
+        return extendIAMFormList().then(() => 
+          expect(document.getElementById('AESW_ColorLine')).to.be.null);
       })
     })
   })
@@ -58,23 +58,23 @@ describe('ContentScripts', () => {
       it('attaches color line', () => {
         loadFixtures('awsmc-federated-switched', 'data');
         document.querySelector('#nav-usernameMenu .nav-elt-label').textContent = 'b-prod';
-        extendIAMFormList();
-        expect(document.getElementById('AESW_ColorLine')).to.exist;
+        return extendIAMFormList().then(() => 
+          expect(document.getElementById('AESW_ColorLine')).to.exist);
       })
 
       it('attaches image', () => {
         loadFixtures('awsmc-federated-switched', 'data');
         document.querySelector('#nav-usernameMenu .nav-elt-label').textContent = 'b-prod-image';
-        extendIAMFormList();
-        expect(document.getElementById('AESW_Image')).to.exist;
+        return extendIAMFormList().then(() => 
+          expect(document.getElementById('AESW_Image')).to.exist);
       })
 
       context('color not defined', () => {
         it('does not attach color line', () => {
           loadFixtures('awsmc-federated-switched', 'data');
           document.querySelector('#nav-usernameMenu .nav-elt-label').textContent = 'b-renpou';
-          extendIAMFormList();
-          expect(document.getElementById('AESW_ColorLine')).to.be.null;
+          return extendIAMFormList().then(() => 
+            expect(document.getElementById('AESW_ColorLine')).to.be.null);
         })
       })
 
@@ -82,8 +82,8 @@ describe('ContentScripts', () => {
         it('does not attach image', () => {
           loadFixtures('awsmc-federated-switched', 'data');
           document.querySelector('#nav-usernameMenu .nav-elt-label').textContent = 'b-renpou';
-          extendIAMFormList();
-          expect(document.getElementById('AESW_Image')).to.be.null;
+          return extendIAMFormList().then(() => 
+            expect(document.getElementById('AESW_Image')).to.be.null);
         })
       })
     })
@@ -92,16 +92,16 @@ describe('ContentScripts', () => {
       it('attaches color line', () => {
         loadFixtures('awsmc-federated-switched', 'data');
         document.querySelector('#nav-usernameMenu .nav-elt-label').textContent = 'b-prod  |  666611114444';
-        extendIAMFormList();
-        expect(document.getElementById('AESW_ColorLine')).to.exist;
+        return extendIAMFormList().then(() => 
+          expect(document.getElementById('AESW_ColorLine')).to.exist);
       })
 
       context('color not defined', () => {
         it('does not attach color line', () => {
           loadFixtures('awsmc-federated-switched', 'data');
           document.querySelector('#nav-usernameMenu .nav-elt-label').textContent = 'b-renpou  |  666611115555';
-          extendIAMFormList();
-          expect(document.getElementById('AESW_ColorLine')).to.be.null;
+          return extendIAMFormList().then(() => 
+            expect(document.getElementById('AESW_ColorLine')).to.be.null);
         })
       })
     })
@@ -110,8 +110,8 @@ describe('ContentScripts', () => {
       it('does not attach color line', () => {
         loadFixtures('awsmc-federated-switched', 'data');
         document.querySelector('#nav-usernameMenu .nav-elt-label').textContent = 'other  |  000000000000';
-        extendIAMFormList();
-        expect(document.getElementById('AESW_ColorLine')).to.be.null;
+        return extendIAMFormList().then(() => 
+          expect(document.getElementById('AESW_ColorLine')).to.be.null);
       })
     })
 
@@ -119,8 +119,8 @@ describe('ContentScripts', () => {
       it('does not attach icon', () => {
         loadFixtures('awsmc-federated-switched', 'data');
         document.querySelector('#nav-usernameMenu .nav-elt-label').textContent = 'other  |  000000000000';
-        extendIAMFormList();
-        expect(document.getElementById('AESW_Image')).to.be.null;
+        return extendIAMFormList().then(() => 
+          expect(document.getElementById('AESW_Image')).to.be.null);
       })
     })
   })

--- a/test/content_auto_assume_last_role.test.js
+++ b/test/content_auto_assume_last_role.test.js
@@ -4,12 +4,13 @@ describe('Auto assume last assumed role on content script', () => {
     document.getElementById('awsc-login-display-name-account').textContent = '5555-1111-2222';
     chrome.storage.sync.data.autoAssumeLastRole = true;
     chrome.storage.sync.data.lastRole_555511112222_tilfin = '555511113333_stg-role';
-    extendIAMFormList();
-    const form = document.querySelector('#awsc-username-menu-recent-roles li:nth-child(7)')
-    form.onsubmit = () => {
-      done();
-      return false;
-    }
+    extendIAMFormList().then(() => {
+      const form = document.querySelector('#awsc-username-menu-recent-roles li:nth-child(7)')
+      form.onsubmit = () => {
+        done();
+        return false;
+      }
+    });
   })
 
   context('hides histories', () => {
@@ -19,12 +20,13 @@ describe('Auto assume last assumed role on content script', () => {
       chrome.storage.sync.data.hidesHistory = true;
       chrome.storage.sync.data.autoAssumeLastRole = true;
       chrome.storage.sync.data.lastRole_555511112222_tilfin = '555511113333_stg-role';
-      extendIAMFormList();
-      const form = document.querySelector('#awsc-username-menu-recent-roles li:nth-child(3)')
-      form.onsubmit = () => {
-        done();
-        return false;
-      }
+      extendIAMFormList().then(() => {
+        const form = document.querySelector('#awsc-username-menu-recent-roles li:nth-child(3)')
+        form.onsubmit = () => {
+          done();
+          return false;
+        }
+      });
     })
   })
 
@@ -34,13 +36,14 @@ describe('Auto assume last assumed role on content script', () => {
       document.getElementById('awsc-login-display-name-account').textContent = '5555-1111-2222';
       chrome.storage.sync.data.autoAssumeLastRole = false;
       chrome.storage.sync.data.lastRole_555511112222_tilfin = '555511113333_stg-role';
-      extendIAMFormList();
-      const form = document.querySelector('#awsc-username-menu-recent-roles li:nth-child(7)')
-      form.onsubmit = () => {
-        done('must not occurr');
-        return false;
-      }
-      done();
+      extendIAMFormList().then(() => {
+        const form = document.querySelector('#awsc-username-menu-recent-roles li:nth-child(7)')
+        form.onsubmit = () => {
+          done('must not occurr');
+          return false;
+        }
+        done();
+      });
     })
   })
 
@@ -50,14 +53,15 @@ describe('Auto assume last assumed role on content script', () => {
       document.getElementById('awsc-login-display-name-account').textContent = '5555-1111-2222';
       chrome.storage.sync.data.autoAssumeLastRole = true;
       chrome.storage.sync.data.lastRole_555511112222_tilfin = '555511113333_stg-role';
-      extendIAMFormList();
-      const form = document.getElementById('awsc-exit-role-form');
-      form.addEventListener('submit', function(e) {
-        expect(chrome.storage.sync.data.lastRole_555511112222_tilfin).to.null;
-        e.preventDefault(); 
-        done();
+      extendIAMFormList().then(() => {
+        const form = document.getElementById('awsc-exit-role-form');
+        form.addEventListener('submit', function(e) {
+          expect(chrome.storage.sync.data.lastRole_555511112222_tilfin).to.null;
+          e.preventDefault(); 
+          done();
+        });
+        form.querySelector('input[type="submit"]').click();
       });
-      form.querySelector('input[type="submit"]').click();
     })
   })
 })

--- a/test/content_auto_assume_last_role.test.js
+++ b/test/content_auto_assume_last_role.test.js
@@ -1,9 +1,27 @@
 describe('Auto assume last assumed role on content script', () => {
+  afterEach(() => { browser.runtime.data['get-current-tab-context'] = '' })
+
   it('triggers clicking the submit button of target role form', (done) => {
     loadFixtures('awsmc-iam', 'data');
     document.getElementById('awsc-login-display-name-account').textContent = '5555-1111-2222';
     chrome.storage.sync.data.autoAssumeLastRole = true;
     chrome.storage.sync.data.lastRole_555511112222_tilfin = '555511113333_stg-role';
+    extendIAMFormList().then(() => {
+      const form = document.querySelector('#awsc-username-menu-recent-roles li:nth-child(7)')
+      form.onsubmit = () => {
+        done();
+        return false;
+      }
+    });
+  })
+
+  it('triggers clicking the submit button of target role form in a tab container', (done) => {
+    loadFixtures('awsmc-iam', 'data');
+    document.getElementById('awsc-login-display-name-account').textContent = '5555-1111-2222';
+    browser.runtime.data['get-current-tab-context'] = 'test-context';
+    chrome.storage.sync.data.autoAssumeLastRole = true;
+    chrome.storage.sync.data['lastRole_555511112222_tilfin'] = '123456789012-role';
+    chrome.storage.sync.data['lastRole_555511112222_tilfin_test-context'] = '555511113333_stg-role';
     extendIAMFormList().then(() => {
       const form = document.querySelector('#awsc-username-menu-recent-roles li:nth-child(7)')
       form.onsubmit = () => {

--- a/test/content_redirect_uri.test.js
+++ b/test/content_redirect_uri.test.js
@@ -12,7 +12,7 @@ describe('Reset the region of redirect_uri on content script', () => {
     loadFixtures('awsmc-iam', 'data');
     document.getElementById('awsc-login-display-name-account').textContent = '5555-1111-2222';
     chrome.storage.sync.data.hidesHistory = true;
-    extendIAMFormList();
+    return extendIAMFormList();
   })
 
   context('clicking a-prod of list when base-a profile', () => {

--- a/test/content_reset_region.test.js
+++ b/test/content_reset_region.test.js
@@ -12,7 +12,7 @@ describe('Content redirect_uri', () => {
     loadFixtures('awsmc-iam', 'data');
     document.getElementById('awsc-login-display-name-account').textContent = '5555-1111-2222';
     chrome.storage.sync.data.hidesHistory = true;
-    extendIAMFormList();
+    return extendIAMFormList();
   })
 
   context('clicking a-prod of list when base-a profile', () => {

--- a/test/content_scripts.test.js
+++ b/test/content_scripts.test.js
@@ -10,20 +10,22 @@ describe('ContentScripts', () => {
     })
 
     it('creates awsc-username-menu-recent-roles', () => {
-      extendIAMFormList();
-      expect(document.body.className.includes('user-type-iam')).to.be.true;
-      expect(document.getElementById('awsc-username-menu-recent-roles')).to.exist;
+      return extendIAMFormList().then(() => {
+        expect(document.body.className.includes('user-type-iam')).to.be.true;
+        expect(document.getElementById('awsc-username-menu-recent-roles')).to.exist;
+      });
     })
   })
 
   context('when iam user have signed in with 5 histories', () => {
     it('load base aws account is number', () => {
       loadFixtures('awsmc-iam');
-      extendIAMFormList();
+      return extendIAMFormList().then(() => {
 
-      expect(document.body.className.includes('user-type-iam')).to.be.true;
-      expect(document.body.className.includes('user-type-federated')).to.be.false;
-      expect(document.querySelectorAll('#awsc-username-menu-recent-roles li').length).to.eq(5);
+        expect(document.body.className.includes('user-type-iam')).to.be.true;
+        expect(document.body.className.includes('user-type-federated')).to.be.false;
+        expect(document.querySelectorAll('#awsc-username-menu-recent-roles li').length).to.eq(5);
+      });
     })
 
     context('not hidesHistory', () => {
@@ -31,15 +33,16 @@ describe('ContentScripts', () => {
         it('appends 2 roles but one of them already exists', () => {
           loadFixtures('awsmc-iam', 'data');
           chrome.storage.sync.data.hidesHistory = false;
-          extendIAMFormList();
+          return extendIAMFormList().then(() => {
 
-          expect(document.body.className.includes('user-type-iam')).to.be.true;
-          expect(document.body.className.includes('user-type-federated')).to.be.false;
+            expect(document.body.className.includes('user-type-iam')).to.be.true;
+            expect(document.body.className.includes('user-type-federated')).to.be.false;
 
-          const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-          expect(roles.length).to.eq(6);
-          expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
-          expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('independence_role');
+            const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
+            expect(roles.length).to.eq(6);
+            expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
+            expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('independence_role');
+          });
         })
       })
 
@@ -48,18 +51,19 @@ describe('ContentScripts', () => {
           loadFixtures('awsmc-exclude-unrelated-profile-from-history', 'data');
           document.getElementById('awsc-login-display-name-account').textContent = '5555-1111-2222';
           chrome.storage.sync.data.hidesHistory = false;
-          extendIAMFormList();
+          return extendIAMFormList().then(() => {
 
-          const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-          expect(roles.length).to.eq(5);
-          expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('stg-role_history');
-          expect(roles[0].querySelector('input[type="submit"]').value).to.eq('a-stg');
-          expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
-          expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('independence_role');
-          expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('prod-role');
-          expect(roles[3].querySelector('input[type="submit"]').value).to.eq('a-prod  |  555511114444');
-          expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('stg-role-image');
-          expect(roles[4].querySelector('input[type="submit"]').value).to.eq('a-stg-image  |  555511113333');
+            const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
+            expect(roles.length).to.eq(5);
+            expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('stg-role_history');
+            expect(roles[0].querySelector('input[type="submit"]').value).to.eq('a-stg');
+            expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
+            expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('independence_role');
+            expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('prod-role');
+            expect(roles[3].querySelector('input[type="submit"]').value).to.eq('a-prod  |  555511114444');
+            expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('stg-role-image');
+            expect(roles[4].querySelector('input[type="submit"]').value).to.eq('a-stg-image  |  555511113333');
+          });
         })
       })
     })
@@ -69,15 +73,16 @@ describe('ContentScripts', () => {
         it('hides histories and appends 2 roles', () => {
           loadFixtures('awsmc-iam', 'data');
           chrome.storage.sync.data.hidesHistory = true;
-          extendIAMFormList();
+          return extendIAMFormList().then(() => {
 
-          expect(document.body.className.includes('user-type-iam')).to.be.true;
-          expect(document.body.className.includes('user-type-federated')).to.be.false;
+            expect(document.body.className.includes('user-type-iam')).to.be.true;
+            expect(document.body.className.includes('user-type-federated')).to.be.false;
 
-          const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-          expect(roles.length).to.eq(2);
-          expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
-          expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
+            const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
+            expect(roles.length).to.eq(2);
+            expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
+            expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
+          });
         })
       })
 
@@ -86,21 +91,22 @@ describe('ContentScripts', () => {
           loadFixtures('awsmc-iam', 'data');
           document.getElementById('awsc-login-display-name-account').textContent = '5555-1111-2222';
           chrome.storage.sync.data.hidesHistory = true;
-          extendIAMFormList();
+          return extendIAMFormList().then(() => {
 
-          expect(document.body.className.includes('user-type-iam')).to.be.true;
-          expect(document.body.className.includes('user-type-federated')).to.be.false;
+            expect(document.body.className.includes('user-type-iam')).to.be.true;
+            expect(document.body.className.includes('user-type-federated')).to.be.false;
 
-          const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-          expect(roles.length).to.eq(5);
-          expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
-          expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
-          expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
-          expect(roles[2].querySelector('input[type="submit"]').value).to.eq('a-stg  |  555511113333');
-          expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('prod-role');
-          expect(roles[3].querySelector('input[type="submit"]').value).to.eq('a-prod  |  555511114444');
-          expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('stg-role-image');
-          expect(roles[4].querySelector('input[type="submit"]').value).to.eq('a-stg-image  |  555511113333');
+            const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
+            expect(roles.length).to.eq(5);
+            expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
+            expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
+            expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
+            expect(roles[2].querySelector('input[type="submit"]').value).to.eq('a-stg  |  555511113333');
+            expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('prod-role');
+            expect(roles[3].querySelector('input[type="submit"]').value).to.eq('a-prod  |  555511114444');
+            expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('stg-role-image');
+            expect(roles[4].querySelector('input[type="submit"]').value).to.eq('a-stg-image  |  555511113333');
+          });
         })
       })
 
@@ -109,23 +115,24 @@ describe('ContentScripts', () => {
           loadFixtures('awsmc-iam', 'data');
           document.getElementById('awsc-login-display-name-account').textContent = '6666-1111-2222';
           chrome.storage.sync.data.hidesHistory = true;
-          extendIAMFormList();
+          return extendIAMFormList().then(() => {
 
-          expect(document.body.className.includes('user-type-iam')).to.be.true;
-          expect(document.body.className.includes('user-type-federated')).to.be.false;
+            expect(document.body.className.includes('user-type-iam')).to.be.true;
+            expect(document.body.className.includes('user-type-federated')).to.be.false;
 
-          const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-          expect(roles.length).to.eq(6);
-          expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
-          expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
-          expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
-          expect(roles[2].querySelector('input[type="submit"]').value).to.eq('b-stg  |  666611113333');
-          expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('prod-role');
-          expect(roles[3].querySelector('input[type="submit"]').value).to.eq('b-prod  |  666611114444');
-          expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('renpou');
-          expect(roles[4].querySelector('input[type="submit"]').value).to.eq('b-renpou  |  666611115555');
-          expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('prod-role-image');
-          expect(roles[5].querySelector('input[type="submit"]').value).to.eq('b-prod-image  |  666611114444');
+            const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
+            expect(roles.length).to.eq(6);
+            expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
+            expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
+            expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
+            expect(roles[2].querySelector('input[type="submit"]').value).to.eq('b-stg  |  666611113333');
+            expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('prod-role');
+            expect(roles[3].querySelector('input[type="submit"]').value).to.eq('b-prod  |  666611114444');
+            expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('renpou');
+            expect(roles[4].querySelector('input[type="submit"]').value).to.eq('b-renpou  |  666611115555');
+            expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('prod-role-image');
+            expect(roles[5].querySelector('input[type="submit"]').value).to.eq('b-prod-image  |  666611114444');
+          });
         })
       })
     })
@@ -137,25 +144,26 @@ describe('ContentScripts', () => {
           document.getElementById('awsc-login-display-name-account').textContent = '6666-1111-2222';
           chrome.storage.sync.data.hidesHistory = true;
           chrome.storage.sync.data.hidesAccountId = true;
-          extendIAMFormList();
+          return extendIAMFormList().then(() => {
 
-          expect(document.body.className.includes('user-type-iam')).to.be.true;
-          expect(document.body.className.includes('user-type-federated')).to.be.false;
+            expect(document.body.className.includes('user-type-iam')).to.be.true;
+            expect(document.body.className.includes('user-type-federated')).to.be.false;
 
-          const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-          expect(roles.length).to.eq(6);
-          expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
-          expect(roles[0].querySelector('input[type="submit"]').value).to.eq('independence');
-          expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
-          expect(roles[1].querySelector('input[type="submit"]').value).to.eq('history-contained');
-          expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
-          expect(roles[2].querySelector('input[type="submit"]').value).to.eq('b-stg');
-          expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('prod-role');
-          expect(roles[3].querySelector('input[type="submit"]').value).to.eq('b-prod');
-          expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('renpou');
-          expect(roles[4].querySelector('input[type="submit"]').value).to.eq('b-renpou');
-          expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('prod-role-image');
-          expect(roles[5].querySelector('input[type="submit"]').value).to.eq('b-prod-image');
+            const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
+            expect(roles.length).to.eq(6);
+            expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
+            expect(roles[0].querySelector('input[type="submit"]').value).to.eq('independence');
+            expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
+            expect(roles[1].querySelector('input[type="submit"]').value).to.eq('history-contained');
+            expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
+            expect(roles[2].querySelector('input[type="submit"]').value).to.eq('b-stg');
+            expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('prod-role');
+            expect(roles[3].querySelector('input[type="submit"]').value).to.eq('b-prod');
+            expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('renpou');
+            expect(roles[4].querySelector('input[type="submit"]').value).to.eq('b-renpou');
+            expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('prod-role-image');
+            expect(roles[5].querySelector('input[type="submit"]').value).to.eq('b-prod-image');
+          });
         })
       })
     })
@@ -165,23 +173,24 @@ describe('ContentScripts', () => {
         loadFixtures('awsmc-iam', 'data');
         document.getElementById('awsc-login-display-name-account').textContent = '6666-1111-2222';
         chrome.storage.sync.data.showOnlyMatchingRoles = true;
-        extendIAMFormList();
+        return extendIAMFormList().then(() => {
 
-        expect(document.body.className.includes('user-type-iam')).to.be.true;
-        expect(document.body.className.includes('user-type-federated')).to.be.false;
+          expect(document.body.className.includes('user-type-iam')).to.be.true;
+          expect(document.body.className.includes('user-type-federated')).to.be.false;
 
-        const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-        expect(roles.length).to.eq(10);
-        expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
-        expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('independence_role');
-        expect(roles[6].querySelector('input[name="roleName"]').value).to.eq('stg-role');
-        expect(roles[6].querySelector('input[type="submit"]').value).to.eq('b-stg  |  666611113333');
-        expect(roles[7].querySelector('input[name="roleName"]').value).to.eq('prod-role');
-        expect(roles[7].querySelector('input[type="submit"]').value).to.eq('b-prod  |  666611114444');
-        expect(roles[8].querySelector('input[name="roleName"]').value).to.eq('renpou');
-        expect(roles[8].querySelector('input[type="submit"]').value).to.eq('b-renpou  |  666611115555');
-        expect(roles[9].querySelector('input[name="roleName"]').value).to.eq('prod-role-image');
-        expect(roles[9].querySelector('input[type="submit"]').value).to.eq('b-prod-image  |  666611114444');
+          const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
+          expect(roles.length).to.eq(10);
+          expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
+          expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('independence_role');
+          expect(roles[6].querySelector('input[name="roleName"]').value).to.eq('stg-role');
+          expect(roles[6].querySelector('input[type="submit"]').value).to.eq('b-stg  |  666611113333');
+          expect(roles[7].querySelector('input[name="roleName"]').value).to.eq('prod-role');
+          expect(roles[7].querySelector('input[type="submit"]').value).to.eq('b-prod  |  666611114444');
+          expect(roles[8].querySelector('input[name="roleName"]').value).to.eq('renpou');
+          expect(roles[8].querySelector('input[type="submit"]').value).to.eq('b-renpou  |  666611115555');
+          expect(roles[9].querySelector('input[name="roleName"]').value).to.eq('prod-role-image');
+          expect(roles[9].querySelector('input[type="submit"]').value).to.eq('b-prod-image  |  666611114444');
+        });
       })
     })
 
@@ -191,103 +200,10 @@ describe('ContentScripts', () => {
         document.getElementById('awsc-login-display-name-account').textContent = '6666-1111-2222';
         chrome.storage.sync.data.hidesHistory = true;
         chrome.storage.sync.data.showOnlyMatchingRoles = true;
-        extendIAMFormList();
+        return extendIAMFormList().then(() => {
 
-        expect(document.body.className.includes('user-type-iam')).to.be.true;
-        expect(document.body.className.includes('user-type-federated')).to.be.false;
-
-        const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-        expect(roles.length).to.eq(6);
-        expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
-        expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
-        expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
-        expect(roles[2].querySelector('input[type="submit"]').value).to.eq('b-stg  |  666611113333');
-        expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('prod-role');
-        expect(roles[3].querySelector('input[type="submit"]').value).to.eq('b-prod  |  666611114444');
-        expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('renpou');
-        expect(roles[4].querySelector('input[type="submit"]').value).to.eq('b-renpou  |  666611115555');
-        expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('prod-role-image');
-        expect(roles[5].querySelector('input[type="submit"]').value).to.eq('b-prod-image  |  666611114444');
-      })
-    })
-  })
-
-  context('when federated user have signed in with 5 histories', () => {
-    it('load base aws account is number', () => {
-      loadFixtures('awsmc-federated');
-      extendIAMFormList();
-
-      expect(document.body.className.includes('user-type-iam')).to.be.false;
-      expect(document.body.className.includes('user-type-federated')).to.be.true;
-      expect(document.querySelectorAll('#awsc-username-menu-recent-roles li').length).to.eq(5);
-    })
-
-    context('not hidesHistory', () => {
-      context('base profile is undefined', () => {
-        it('appends 2 roles but one of them already exists', () => {
-          loadFixtures('awsmc-federated', 'data');
-          extendIAMFormList();
-
-          expect(document.body.className.includes('user-type-iam')).to.be.false;
-          expect(document.body.className.includes('user-type-federated')).to.be.true;
-
-          const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-          expect(roles.length).to.eq(6);
-          expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
-          expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('independence_role');
-        })
-      })
-    })
-
-    context('hidesHistory', () => {
-      context('base profile is undefined', () => {
-        it('hides histories and appends 2 roles', () => {
-          loadFixtures('awsmc-federated', 'data');
-          chrome.storage.sync.data.hidesHistory = true;
-          extendIAMFormList();
-
-          expect(document.body.className.includes('user-type-iam')).to.be.false;
-          expect(document.body.className.includes('user-type-federated')).to.be.true;
-
-          const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-          expect(roles.length).to.eq(2);
-          expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
-          expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
-        })
-      })
-
-      context('base-a profile', () => {
-        it('hides histories and appends 4 roles', () => {
-          loadFixtures('awsmc-federated', 'data');
-          document.getElementById('awsc-login-display-name-account').textContent = '5555-1111-2222';
-          chrome.storage.sync.data.hidesHistory = true;
-          extendIAMFormList();
-
-          expect(document.body.className.includes('user-type-federated')).to.be.true;
-          expect(document.body.className.includes('user-type-iam')).to.be.false;
-
-          const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-          expect(roles.length).to.eq(5);
-          expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
-          expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
-          expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
-          expect(roles[2].querySelector('input[type="submit"]').value).to.eq('a-stg  |  555511113333');
-          expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('prod-role');
-          expect(roles[3].querySelector('input[type="submit"]').value).to.eq('a-prod  |  555511114444');
-          expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('stg-role-image');
-          expect(roles[4].querySelector('input[type="submit"]').value).to.eq('a-stg-image  |  555511113333');
-        })
-      })
-
-      context('base-b profile', () => {
-        it('hides histories and appends 5 roles', () => {
-          loadFixtures('awsmc-federated', 'data');
-          document.getElementById('awsc-login-display-name-account').textContent = '6666-1111-2222';
-          chrome.storage.sync.data.hidesHistory = true;
-          extendIAMFormList();
-
-          expect(document.body.className.includes('user-type-federated')).to.be.true;
-          expect(document.body.className.includes('user-type-iam')).to.be.false;
+          expect(document.body.className.includes('user-type-iam')).to.be.true;
+          expect(document.body.className.includes('user-type-federated')).to.be.false;
 
           const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
           expect(roles.length).to.eq(6);
@@ -301,6 +217,105 @@ describe('ContentScripts', () => {
           expect(roles[4].querySelector('input[type="submit"]').value).to.eq('b-renpou  |  666611115555');
           expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('prod-role-image');
           expect(roles[5].querySelector('input[type="submit"]').value).to.eq('b-prod-image  |  666611114444');
+        });
+      })
+    })
+  })
+
+  context('when federated user have signed in with 5 histories', () => {
+    it('load base aws account is number', () => {
+      loadFixtures('awsmc-federated');
+      return extendIAMFormList().then(() => {
+
+        expect(document.body.className.includes('user-type-iam')).to.be.false;
+        expect(document.body.className.includes('user-type-federated')).to.be.true;
+        expect(document.querySelectorAll('#awsc-username-menu-recent-roles li').length).to.eq(5);
+      });
+    })
+
+    context('not hidesHistory', () => {
+      context('base profile is undefined', () => {
+        it('appends 2 roles but one of them already exists', () => {
+          loadFixtures('awsmc-federated', 'data');
+          return extendIAMFormList().then(() => {
+
+            expect(document.body.className.includes('user-type-iam')).to.be.false;
+            expect(document.body.className.includes('user-type-federated')).to.be.true;
+
+            const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
+            expect(roles.length).to.eq(6);
+            expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
+            expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('independence_role');
+          });
+        })
+      })
+    })
+
+    context('hidesHistory', () => {
+      context('base profile is undefined', () => {
+        it('hides histories and appends 2 roles', () => {
+          loadFixtures('awsmc-federated', 'data');
+          chrome.storage.sync.data.hidesHistory = true;
+          return extendIAMFormList().then(() => {
+
+            expect(document.body.className.includes('user-type-iam')).to.be.false;
+            expect(document.body.className.includes('user-type-federated')).to.be.true;
+
+            const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
+            expect(roles.length).to.eq(2);
+            expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
+            expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
+          });
+        })
+      })
+
+      context('base-a profile', () => {
+        it('hides histories and appends 4 roles', () => {
+          loadFixtures('awsmc-federated', 'data');
+          document.getElementById('awsc-login-display-name-account').textContent = '5555-1111-2222';
+          chrome.storage.sync.data.hidesHistory = true;
+          return extendIAMFormList().then(() => {
+
+            expect(document.body.className.includes('user-type-federated')).to.be.true;
+            expect(document.body.className.includes('user-type-iam')).to.be.false;
+
+            const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
+            expect(roles.length).to.eq(5);
+            expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
+            expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
+            expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
+            expect(roles[2].querySelector('input[type="submit"]').value).to.eq('a-stg  |  555511113333');
+            expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('prod-role');
+            expect(roles[3].querySelector('input[type="submit"]').value).to.eq('a-prod  |  555511114444');
+            expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('stg-role-image');
+            expect(roles[4].querySelector('input[type="submit"]').value).to.eq('a-stg-image  |  555511113333');
+          });
+        })
+      })
+
+      context('base-b profile', () => {
+        it('hides histories and appends 5 roles', () => {
+          loadFixtures('awsmc-federated', 'data');
+          document.getElementById('awsc-login-display-name-account').textContent = '6666-1111-2222';
+          chrome.storage.sync.data.hidesHistory = true;
+          return extendIAMFormList().then(() => {
+
+            expect(document.body.className.includes('user-type-federated')).to.be.true;
+            expect(document.body.className.includes('user-type-iam')).to.be.false;
+
+            const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
+            expect(roles.length).to.eq(6);
+            expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
+            expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
+            expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
+            expect(roles[2].querySelector('input[type="submit"]').value).to.eq('b-stg  |  666611113333');
+            expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('prod-role');
+            expect(roles[3].querySelector('input[type="submit"]').value).to.eq('b-prod  |  666611114444');
+            expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('renpou');
+            expect(roles[4].querySelector('input[type="submit"]').value).to.eq('b-renpou  |  666611115555');
+            expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('prod-role-image');
+            expect(roles[5].querySelector('input[type="submit"]').value).to.eq('b-prod-image  |  666611114444');
+          });
         })
       })
     })
@@ -310,17 +325,18 @@ describe('ContentScripts', () => {
         loadFixtures('awsmc-federated', 'data');
         document.getElementById('awsc-login-display-name-account').textContent = '6666-1111-2222';
         chrome.storage.sync.data.showOnlyMatchingRoles = true;
-        extendIAMFormList();
+        return extendIAMFormList().then(() => {
 
-        expect(document.body.className.includes('user-type-federated')).to.be.true;
-        expect(document.body.className.includes('user-type-iam')).to.be.false;
+          expect(document.body.className.includes('user-type-federated')).to.be.true;
+          expect(document.body.className.includes('user-type-iam')).to.be.false;
 
-        const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-        expect(roles.length).to.eq(7);
-        expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
-        expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('independence_role');
-        expect(roles[6].querySelector('input[name="roleName"]').value).to.eq('renpou');
-        expect(roles[6].querySelector('input[type="submit"]').value).to.eq('b-renpou  |  666611115555');
+          const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
+          expect(roles.length).to.eq(7);
+          expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
+          expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('independence_role');
+          expect(roles[6].querySelector('input[name="roleName"]').value).to.eq('renpou');
+          expect(roles[6].querySelector('input[type="submit"]').value).to.eq('b-renpou  |  666611115555');
+        });
       })
     })
 
@@ -330,17 +346,18 @@ describe('ContentScripts', () => {
         document.getElementById('awsc-login-display-name-account').textContent = '6666-1111-2222';
         chrome.storage.sync.data.hidesHistory = true;
         chrome.storage.sync.data.showOnlyMatchingRoles = true;
-        extendIAMFormList();
+        return extendIAMFormList().then(() => {
 
-        expect(document.body.className.includes('user-type-federated')).to.be.true;
-        expect(document.body.className.includes('user-type-iam')).to.be.false;
+          expect(document.body.className.includes('user-type-federated')).to.be.true;
+          expect(document.body.className.includes('user-type-iam')).to.be.false;
 
-        const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-        expect(roles.length).to.eq(3);
-        expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
-        expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
-        expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('renpou');
-        expect(roles[2].querySelector('input[type="submit"]').value).to.eq('b-renpou  |  666611115555');
+          const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
+          expect(roles.length).to.eq(3);
+          expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
+          expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
+          expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('renpou');
+          expect(roles[2].querySelector('input[type="submit"]').value).to.eq('b-renpou  |  666611115555');
+        });
       })
     })
 
@@ -351,16 +368,17 @@ describe('ContentScripts', () => {
         chrome.storage.sync.data.hidesHistory = true;
         chrome.storage.sync.data.hidesAccountId = true;
         chrome.storage.sync.data.showOnlyMatchingRoles = true;
-        extendIAMFormList();
+        return extendIAMFormList().then(() => {
 
-        expect(document.body.className.includes('user-type-federated')).to.be.true;
-        expect(document.body.className.includes('user-type-iam')).to.be.false;
+          expect(document.body.className.includes('user-type-federated')).to.be.true;
+          expect(document.body.className.includes('user-type-iam')).to.be.false;
 
-        const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-        expect(roles.length).to.eq(3);
-        expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
-        expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
-        expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('renpou');
+          const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
+          expect(roles.length).to.eq(3);
+          expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
+          expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
+          expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('renpou');
+        });
       })
     })
     
@@ -371,15 +389,16 @@ describe('ContentScripts', () => {
         chrome.storage.sync.data.hidesHistory = true;
         chrome.storage.sync.data.hidesAccountId = false;
         chrome.storage.sync.data.showOnlyMatchingRoles = true;
-        extendIAMFormList();
+        return extendIAMFormList().then(() => {
         
-        const filter = document.querySelector('#AESR_RoleFilter')      
-        filter.value = "666611115555"
-        filter.dispatchEvent(new KeyboardEvent('keyup',{'key':'5'}))
+          const filter = document.querySelector('#AESR_RoleFilter')      
+          filter.value = "666611115555"
+          filter.dispatchEvent(new KeyboardEvent('keyup',{'key':'5'}))
 
-        const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li[style*="display: block;"]'))
-        expect(roles.length).to.eq(1);
-        expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('renpou');        
+          const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li[style*="display: block;"]'))
+          expect(roles.length).to.eq(1);
+          expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('renpou');        
+        });
       })
     })
 
@@ -390,14 +409,15 @@ describe('ContentScripts', () => {
         chrome.storage.sync.data.hidesHistory = true;
         chrome.storage.sync.data.hidesAccountId = true;
         chrome.storage.sync.data.showOnlyMatchingRoles = true;
-        extendIAMFormList();
+        return extendIAMFormList().then(() => {
         
-        const filter = document.querySelector('#AESR_RoleFilter')      
-        filter.value = "666611115555"
-        filter.dispatchEvent(new KeyboardEvent('keyup',{'key':'5'}))
+          const filter = document.querySelector('#AESR_RoleFilter')      
+          filter.value = "666611115555"
+          filter.dispatchEvent(new KeyboardEvent('keyup',{'key':'5'}))
 
-        const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li[style*="display: block;"]'))
-        expect(roles.length).to.eq(0);
+          const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li[style*="display: block;"]'))
+          expect(roles.length).to.eq(0);
+        });
       })
     })    
   })

--- a/test/content_switched.test.js
+++ b/test/content_switched.test.js
@@ -2,11 +2,12 @@ describe('ContentScripts', () => {
   context('when iam user have signed in with 5 histories', () => {
     it('load base aws account is number', () => {
       loadFixtures('awsmc-iam-switched');
-      extendIAMFormList();
+      return extendIAMFormList().then(() => {
 
-      expect(document.body.className.includes('user-type-federated')).to.be.true;
-      expect(document.body.className.includes('user-type-iam')).to.be.false;
-      expect(document.querySelectorAll('#awsc-username-menu-recent-roles li').length).to.eq(5);
+        expect(document.body.className.includes('user-type-federated')).to.be.true;
+        expect(document.body.className.includes('user-type-iam')).to.be.false;
+        expect(document.querySelectorAll('#awsc-username-menu-recent-roles li').length).to.eq(5);
+      });
     })
 
     context('not hidesHistory', () => {
@@ -14,19 +15,20 @@ describe('ContentScripts', () => {
         it('appends 4 roles but two of them already exist', () => {
           loadFixtures('awsmc-iam-switched', 'data');
           document.getElementById('awsc-login-display-name-account').textContent = '5555-1111-2222';
-          extendIAMFormList();
+          return extendIAMFormList().then(() => {
 
-          expect(document.body.className.includes('user-type-federated')).to.be.true;
-          expect(document.body.className.includes('user-type-iam')).to.be.false;
+            expect(document.body.className.includes('user-type-federated')).to.be.true;
+            expect(document.body.className.includes('user-type-iam')).to.be.false;
 
-          const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-          expect(roles.length).to.eq(8);
-          expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('stg-role');
-          expect(roles[0].querySelector('input[type="submit"]').value).to.eq('a-stg  |  555511113333');
-          expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
-          expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('independence_role');
-          expect(roles[6].querySelector('input[name="roleName"]').value).to.eq('prod-role');
-          expect(roles[6].querySelector('input[type="submit"]').value).to.eq('a-prod  |  555511114444');
+            const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
+            expect(roles.length).to.eq(8);
+            expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('stg-role');
+            expect(roles[0].querySelector('input[type="submit"]').value).to.eq('a-stg  |  555511113333');
+            expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
+            expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('independence_role');
+            expect(roles[6].querySelector('input[name="roleName"]').value).to.eq('prod-role');
+            expect(roles[6].querySelector('input[type="submit"]').value).to.eq('a-prod  |  555511114444');
+          });
         })
       })
     })
@@ -37,18 +39,19 @@ describe('ContentScripts', () => {
           loadFixtures('awsmc-iam-switched', 'data');
           document.getElementById('awsc-login-display-name-account').textContent = '5555-1111-2222';
           chrome.storage.sync.data.hidesHistory = true;
-          extendIAMFormList();
+          return extendIAMFormList().then(() => {
 
-          expect(document.body.className.includes('user-type-federated')).to.be.true;
-          expect(document.body.className.includes('user-type-iam')).to.be.false;
+            expect(document.body.className.includes('user-type-federated')).to.be.true;
+            expect(document.body.className.includes('user-type-iam')).to.be.false;
 
-          const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-          expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
-          expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
-          expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
-          expect(roles[2].querySelector('input[type="submit"]').value).to.eq('a-stg  |  555511113333');
-          expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('prod-role');
-          expect(roles[3].querySelector('input[type="submit"]').value).to.eq('a-prod  |  555511114444');
+            const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
+            expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
+            expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
+            expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
+            expect(roles[2].querySelector('input[type="submit"]').value).to.eq('a-stg  |  555511113333');
+            expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('prod-role');
+            expect(roles[3].querySelector('input[type="submit"]').value).to.eq('a-prod  |  555511114444');
+          });
         })
       })
 
@@ -57,23 +60,24 @@ describe('ContentScripts', () => {
           loadFixtures('awsmc-iam-switched', 'data');
           document.getElementById('awsc-login-display-name-account').textContent = '6666-1111-2222';
           chrome.storage.sync.data.hidesHistory = true;
-          extendIAMFormList();
+          return extendIAMFormList().then(() => {
 
-          expect(document.body.className.includes('user-type-federated')).to.be.true;
-          expect(document.body.className.includes('user-type-iam')).to.be.false;
+            expect(document.body.className.includes('user-type-federated')).to.be.true;
+            expect(document.body.className.includes('user-type-iam')).to.be.false;
 
-          const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-          expect(roles.length).to.eq(6);
-          expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
-          expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
-          expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
-          expect(roles[2].querySelector('input[type="submit"]').value).to.eq('b-stg  |  666611113333');
-          expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('prod-role');
-          expect(roles[3].querySelector('input[type="submit"]').value).to.eq('b-prod  |  666611114444');
-          expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('renpou');
-          expect(roles[4].querySelector('input[type="submit"]').value).to.eq('b-renpou  |  666611115555');
-          expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('prod-role-image');
-          expect(roles[5].querySelector('input[type="submit"]').value).to.eq('b-prod-image  |  666611114444');
+            const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
+            expect(roles.length).to.eq(6);
+            expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
+            expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
+            expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
+            expect(roles[2].querySelector('input[type="submit"]').value).to.eq('b-stg  |  666611113333');
+            expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('prod-role');
+            expect(roles[3].querySelector('input[type="submit"]').value).to.eq('b-prod  |  666611114444');
+            expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('renpou');
+            expect(roles[4].querySelector('input[type="submit"]').value).to.eq('b-renpou  |  666611115555');
+            expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('prod-role-image');
+            expect(roles[5].querySelector('input[type="submit"]').value).to.eq('b-prod-image  |  666611114444');
+          });
         })
       })
     })
@@ -85,25 +89,26 @@ describe('ContentScripts', () => {
           document.getElementById('awsc-login-display-name-account').textContent = '6666-1111-2222';
           chrome.storage.sync.data.hidesHistory = true;
           chrome.storage.sync.data.hidesAccountId = true;
-          extendIAMFormList();
+          return extendIAMFormList().then(() => {
 
-          expect(document.body.className.includes('user-type-federated')).to.be.true;
-          expect(document.body.className.includes('user-type-iam')).to.be.false;
+            expect(document.body.className.includes('user-type-federated')).to.be.true;
+            expect(document.body.className.includes('user-type-iam')).to.be.false;
 
-          const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-          expect(roles.length).to.eq(6);
-          expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
-          expect(roles[0].querySelector('input[type="submit"]').value).to.eq('independence');
-          expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
-          expect(roles[1].querySelector('input[type="submit"]').value).to.eq('history-contained');
-          expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
-          expect(roles[2].querySelector('input[type="submit"]').value).to.eq('b-stg');
-          expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('prod-role');
-          expect(roles[3].querySelector('input[type="submit"]').value).to.eq('b-prod');
-          expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('renpou');
-          expect(roles[4].querySelector('input[type="submit"]').value).to.eq('b-renpou');
-          expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('prod-role-image');
-          expect(roles[5].querySelector('input[type="submit"]').value).to.eq('b-prod-image');
+            const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
+            expect(roles.length).to.eq(6);
+            expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
+            expect(roles[0].querySelector('input[type="submit"]').value).to.eq('independence');
+            expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
+            expect(roles[1].querySelector('input[type="submit"]').value).to.eq('history-contained');
+            expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
+            expect(roles[2].querySelector('input[type="submit"]').value).to.eq('b-stg');
+            expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('prod-role');
+            expect(roles[3].querySelector('input[type="submit"]').value).to.eq('b-prod');
+            expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('renpou');
+            expect(roles[4].querySelector('input[type="submit"]').value).to.eq('b-renpou');
+            expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('prod-role-image');
+            expect(roles[5].querySelector('input[type="submit"]').value).to.eq('b-prod-image');
+          });
         })
       })
     })
@@ -113,17 +118,18 @@ describe('ContentScripts', () => {
         loadFixtures('awsmc-iam-switched', 'data');
         document.getElementById('awsc-login-display-name-account').textContent = '6666-1111-2222';
         chrome.storage.sync.data.showOnlyMatchingRoles = true;
-        extendIAMFormList();
+        return extendIAMFormList().then(() => {
 
-        expect(document.body.className.includes('user-type-federated')).to.be.true;
-        expect(document.body.className.includes('user-type-iam')).to.be.false;
+          expect(document.body.className.includes('user-type-federated')).to.be.true;
+          expect(document.body.className.includes('user-type-iam')).to.be.false;
 
-        const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-        expect(roles.length).to.eq(6);
-        expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
-        expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('independence_role');
-        expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('stg-role');
-        expect(roles[5].querySelector('input[type="submit"]').value).to.eq('b-stg  |  666611113333');
+          const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
+          expect(roles.length).to.eq(6);
+          expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
+          expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('independence_role');
+          expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('stg-role');
+          expect(roles[5].querySelector('input[type="submit"]').value).to.eq('b-stg  |  666611113333');
+        });
       })
     })
 
@@ -133,17 +139,18 @@ describe('ContentScripts', () => {
         document.getElementById('awsc-login-display-name-account').textContent = '6666-1111-2222';
         chrome.storage.sync.data.hidesHistory = true;
         chrome.storage.sync.data.showOnlyMatchingRoles = true;
-        extendIAMFormList();
+        return extendIAMFormList().then(() => {
 
-        expect(document.body.className.includes('user-type-federated')).to.be.true;
-        expect(document.body.className.includes('user-type-iam')).to.be.false;
+          expect(document.body.className.includes('user-type-federated')).to.be.true;
+          expect(document.body.className.includes('user-type-iam')).to.be.false;
 
-        const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-        expect(roles.length).to.eq(3);
-        expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
-        expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
-        expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
-        expect(roles[2].querySelector('input[type="submit"]').value).to.eq('b-stg  |  666611113333');
+          const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
+          expect(roles.length).to.eq(3);
+          expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
+          expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
+          expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
+          expect(roles[2].querySelector('input[type="submit"]').value).to.eq('b-stg  |  666611113333');
+        });
       })
     })
   })
@@ -151,11 +158,12 @@ describe('ContentScripts', () => {
   context('when federated user have signed in with 5 histories', () => {
     it('load base aws account is number', () => {
       loadFixtures('awsmc-federated-switched');
-      extendIAMFormList();
+      return extendIAMFormList().then(() => {
 
-      expect(document.body.className.includes('user-type-iam')).to.be.false;
-      expect(document.body.className.includes('user-type-federated')).to.be.true;
-      expect(document.querySelectorAll('#awsc-username-menu-recent-roles li').length).to.eq(5);
+        expect(document.body.className.includes('user-type-iam')).to.be.false;
+        expect(document.body.className.includes('user-type-federated')).to.be.true;
+        expect(document.querySelectorAll('#awsc-username-menu-recent-roles li').length).to.eq(5);
+      });
     })
 
     context('not hidesHistory', () => {
@@ -164,23 +172,24 @@ describe('ContentScripts', () => {
           loadFixtures('awsmc-federated-switched', 'data');
           document.getElementById('awsc-login-display-name-account').textContent = '6666-1111-2222';
           chrome.storage.sync.data.hidesHistory = true;
-          extendIAMFormList();
+          return extendIAMFormList().then(() => {
 
-          expect(document.body.className.includes('user-type-federated')).to.be.true;
-          expect(document.body.className.includes('user-type-iam')).to.be.false;
+            expect(document.body.className.includes('user-type-federated')).to.be.true;
+            expect(document.body.className.includes('user-type-iam')).to.be.false;
 
-          const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-          expect(roles.length).to.eq(6);
-          expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
-          expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
-          expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
-          expect(roles[2].querySelector('input[type="submit"]').value).to.eq('b-stg  |  666611113333');
-          expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('prod-role');
-          expect(roles[3].querySelector('input[type="submit"]').value).to.eq('b-prod  |  666611114444');
-          expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('renpou');
-          expect(roles[4].querySelector('input[type="submit"]').value).to.eq('b-renpou  |  666611115555');
-          expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('prod-role-image');
-          expect(roles[5].querySelector('input[type="submit"]').value).to.eq('b-prod-image  |  666611114444');
+            const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
+            expect(roles.length).to.eq(6);
+            expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
+            expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
+            expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
+            expect(roles[2].querySelector('input[type="submit"]').value).to.eq('b-stg  |  666611113333');
+            expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('prod-role');
+            expect(roles[3].querySelector('input[type="submit"]').value).to.eq('b-prod  |  666611114444');
+            expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('renpou');
+            expect(roles[4].querySelector('input[type="submit"]').value).to.eq('b-renpou  |  666611115555');
+            expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('prod-role-image');
+            expect(roles[5].querySelector('input[type="submit"]').value).to.eq('b-prod-image  |  666611114444');
+          });
         })
       })
     })
@@ -191,23 +200,24 @@ describe('ContentScripts', () => {
           loadFixtures('awsmc-federated-switched', 'data');
           document.getElementById('awsc-login-display-name-account').textContent = '6666-1111-2222';
           chrome.storage.sync.data.hidesHistory = true;
-          extendIAMFormList();
+          return extendIAMFormList().then(() => {
 
-          expect(document.body.className.includes('user-type-federated')).to.be.true;
-          expect(document.body.className.includes('user-type-iam')).to.be.false;
+            expect(document.body.className.includes('user-type-federated')).to.be.true;
+            expect(document.body.className.includes('user-type-iam')).to.be.false;
 
-          const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-          expect(roles.length).to.eq(6);
-          expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
-          expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
-          expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
-          expect(roles[2].querySelector('input[type="submit"]').value).to.eq('b-stg  |  666611113333');
-          expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('prod-role');
-          expect(roles[3].querySelector('input[type="submit"]').value).to.eq('b-prod  |  666611114444');
-          expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('renpou');
-          expect(roles[4].querySelector('input[type="submit"]').value).to.eq('b-renpou  |  666611115555');
-          expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('prod-role-image');
-          expect(roles[5].querySelector('input[type="submit"]').value).to.eq('b-prod-image  |  666611114444');
+            const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
+            expect(roles.length).to.eq(6);
+            expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
+            expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
+            expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('stg-role');
+            expect(roles[2].querySelector('input[type="submit"]').value).to.eq('b-stg  |  666611113333');
+            expect(roles[3].querySelector('input[name="roleName"]').value).to.eq('prod-role');
+            expect(roles[3].querySelector('input[type="submit"]').value).to.eq('b-prod  |  666611114444');
+            expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('renpou');
+            expect(roles[4].querySelector('input[type="submit"]').value).to.eq('b-renpou  |  666611115555');
+            expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('prod-role-image');
+            expect(roles[5].querySelector('input[type="submit"]').value).to.eq('b-prod-image  |  666611114444');
+          });
         })
       })
     })
@@ -217,17 +227,18 @@ describe('ContentScripts', () => {
         loadFixtures('awsmc-federated-switched', 'data');
         document.getElementById('awsc-login-display-name-account').textContent = '6666-1111-2222';
         chrome.storage.sync.data.showOnlyMatchingRoles = true;
-        extendIAMFormList();
+        return extendIAMFormList().then(() => {
 
-        expect(document.body.className.includes('user-type-federated')).to.be.true;
-        expect(document.body.className.includes('user-type-iam')).to.be.false;
+          expect(document.body.className.includes('user-type-federated')).to.be.true;
+          expect(document.body.className.includes('user-type-iam')).to.be.false;
 
-        const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-        expect(roles.length).to.eq(6);
-        expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('renpou');
-        expect(roles[0].querySelector('input[type="submit"]').value).to.eq('b-renpou  |  666611115555');
-        expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
-        expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('independence_role');
+          const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
+          expect(roles.length).to.eq(6);
+          expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('renpou');
+          expect(roles[0].querySelector('input[type="submit"]').value).to.eq('b-renpou  |  666611115555');
+          expect(roles[4].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
+          expect(roles[5].querySelector('input[name="roleName"]').value).to.eq('independence_role');
+        });
       })
     })
 
@@ -237,17 +248,18 @@ describe('ContentScripts', () => {
         document.getElementById('awsc-login-display-name-account').textContent = '6666-1111-2222';
         chrome.storage.sync.data.hidesHistory = true;
         chrome.storage.sync.data.showOnlyMatchingRoles = true;
-        extendIAMFormList();
+        return extendIAMFormList().then(() => {
 
-        expect(document.body.className.includes('user-type-federated')).to.be.true;
-        expect(document.body.className.includes('user-type-iam')).to.be.false;
+          expect(document.body.className.includes('user-type-federated')).to.be.true;
+          expect(document.body.className.includes('user-type-iam')).to.be.false;
 
-        const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
-        expect(roles.length).to.eq(3);
-        expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
-        expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
-        expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('renpou');
-        expect(roles[2].querySelector('input[type="submit"]').value).to.eq('b-renpou  |  666611115555');
+          const roles = Array.from(document.querySelectorAll('#awsc-username-menu-recent-roles li'))
+          expect(roles.length).to.eq(3);
+          expect(roles[0].querySelector('input[name="roleName"]').value).to.eq('independence_role');
+          expect(roles[1].querySelector('input[name="roleName"]').value).to.eq('contained_history_role');
+          expect(roles[2].querySelector('input[name="roleName"]').value).to.eq('renpou');
+          expect(roles[2].querySelector('input[type="submit"]').value).to.eq('b-renpou  |  666611115555');
+        });
       })
     })
   })

--- a/test/helper.test.js
+++ b/test/helper.test.js
@@ -2,14 +2,6 @@ chrome = {
   extension: {
     getURL: function(){}
   },
-  runtime: {
-    sendMessage: function(message) {
-      return Promise.resolve(this.data[message.action]);
-    },
-    data: { 
-      'get-current-tab-context': ''
-    }
-  },
   storage: {
     sync: {
       get: function(names, cb){
@@ -27,6 +19,16 @@ chrome = {
     }
   }
 };
+browser = {
+  runtime: {
+    sendMessage: function(message) {
+      return Promise.resolve(this.data[message.action]);
+    },
+    data: { 
+      'get-current-tab-context': ''
+    }
+  },
+}
 
 function loadFixtures(html, json) {
   const args = [`${html}.html`];

--- a/test/helper.test.js
+++ b/test/helper.test.js
@@ -2,6 +2,14 @@ chrome = {
   extension: {
     getURL: function(){}
   },
+  runtime: {
+    sendMessage: function(message) {
+      return Promise.resolve(this.data[message.action]);
+    },
+    data: { 
+      'get-current-tab-context': ''
+    }
+  },
   storage: {
     sync: {
       get: function(names, cb){


### PR DESCRIPTION
Uses the `cookieStoreId` from Firefox to sandbox the different container tabs. This API is described in https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/Tab and https://wiki.mozilla.org/Security/Contextual_Identity_Project/Containers. 

I am just testing this in Chrome now to ensure it also works. I have tested this in Firefox and it works as expected. This makes the tab containers incredibly useful in an organisation where you have many roles.

Resolves #126 