### PR TITLE
Add keyboard shortcut to open popup

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -34,5 +34,12 @@
   "web_accessible_resources": [
     "js/attach_target.js"
   ],
+  "commands": {
+    "_execute_browser_action": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+Comma"
+      }
+    }
+  },
   "manifest_version": 2
 }


### PR DESCRIPTION
In order to switch between accounts more quickly, I added a keyboard shortcut [for opening the popup](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands#Special_shortcuts).

It is currently using `Ctrl+Shift+,` but [it can be remapped by the user](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands#Updating_shortcuts).

Closes #162 