### PR TITLE
Fix playwright config

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,7 +6,6 @@ export default defineConfig({
       name: 'chrome',
       use: {
         ...devices['Desktop Chrome'],
-        channel: 'chrome'
       },
     },
     {


### PR DESCRIPTION
This pull request makes a small update to the Playwright configuration by removing the explicit `channel: 'chrome'` setting from the Chrome browser configuration.