### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/tilfinltd/aws-extend-switch-roles/security/code-scanning/4](https://github.com/tilfinltd/aws-extend-switch-roles/security/code-scanning/4)

To fix this problem, add an explicit `permissions:` block at the root of the workflow (top level, before `jobs:`), which will apply to all jobs, or at the job level if you want to scope permissions more narrowly. Since this workflow does not appear to require any non-read operations, set the value to the lowest privilege needed: `contents: read`. Insert the following block after the `on:` definition and before the `jobs:` key, i.e., between lines 10 and 11. No imports or additional setup are required—just this YAML block added to this location.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
