### PR TITLE
Fix caching playwright

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Cache Playwright browsers
+        id: cache-playwright-browsers
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
@@ -29,6 +30,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-playwright-
       - name: Install playwright browsers
+        if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps
       - name: Run tests
         run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ test/extension/*
 !test/extension/background.js
 !test/extension/manifest.json
 manifest_*_dev.json
+test-results/


### PR DESCRIPTION
This pull request introduces a small improvement to the Playwright browser caching workflow in `.github/workflows/test.yml`. The change ensures that Playwright browsers are only installed if they are not already present in the cache, which can help speed up CI runs and reduce unnecessary installations.